### PR TITLE
Custom webhook support

### DIFF
--- a/pkg/falcovalues/falcovalues.go
+++ b/pkg/falcovalues/falcovalues.go
@@ -229,23 +229,6 @@ func (c *ConfigBuilder) BuildFalcoValues(ctx context.Context, log logr.Logger, c
 	return falcoChartValues, nil
 }
 
-// get the latest Falco version tagged as "supported"
-// func (c *ConfigBuilder) getDefaultFalcoVersion() (string, error) {
-// 	var latestVersion string = ""
-// 	for _, version := range c.falcoVersions.Falco.FalcoVersions {
-// 		if version.Classification == "supported" {
-// 			if latestVersion == "" || semver.Compare("v"+version.Version, "v"+latestVersion) == 1 {
-// 				latestVersion = version.Version
-// 			}
-// 		}
-// 	}
-// 	if latestVersion != "" {
-// 		return latestVersion, nil
-// 	} else {
-// 		return "", fmt.Errorf("no supported Falco version found")
-// 	}
-// }
-
 // get the latest Falcosidekick version tagged as "supported"
 func (c *ConfigBuilder) getDefaultFalcosidekickVersion() (string, error) {
 	var latestVersion string = ""


### PR DESCRIPTION
**What this PR does / why we need it**:

Add support for custom webhooks as described in
https://github.com/gardener/gardener/blob/a0f959ee152e13a22db1b0d9f6f146bc16c8b7ed/docs/proposals/27-falco-extension.md#proposal

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add support for custom webhook configuration in FalcoServiceConfig.
```
