### PR TITLE
General cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+uname                       := $(shell uname)
+
 ENSURE_GARDENER_MOD         := $(shell go get github.com/gardener/gardener@$$(go list -m -f "{{.Version}}" github.com/gardener/gardener))
 GARDENER_HACK_DIR           := $(shell go list -m -f "{{.Dir}}" github.com/gardener/gardener)/hack
 EXTENSION_PREFIX            := gardener-extension
@@ -21,7 +23,12 @@ IGNORE_OPERATION_ANNOTATION := true
 
 WEBHOOK_CONFIG_PORT    := 8443
 WEBHOOK_CONFIG_MODE    := url
-WEBHOOK_CONFIG_URL     := host.docker.internal:$(WEBHOOK_CONFIG_PORT)
+ifeq ($(uname),Darwin)
+  WEBHOOK_CONFIG_URL     := host.docker.internal:$(WEBHOOK_CONFIG_PORT)
+else
+  localip                := $(shell ip route get 1.2.3.4 | awk '{print $$7}')
+  WEBHOOK_CONFIG_URL     := $(localip):$(WEBHOOK_CONFIG_PORT)
+endif
 EXTENSION_NAMESPACE    :=
 WEBHOOK_PARAM := --webhook-config-url=$(WEBHOOK_CONFIG_URL)
 ifeq ($(WEBHOOK_CONFIG_MODE), service)
@@ -49,12 +56,14 @@ start:
 
 .PHONY: start-admission
 start-admission:
-	@LEADER_ELECTION_NAMESPACE=garden go run \
+	LEADER_ELECTION_NAMESPACE=garden go run \
 		-ldflags $(LD_FLAGS) \
 		./cmd/$(EXTENSION_PREFIX)-$(ADMISSION_NAME) \
 		--webhook-config-server-host=0.0.0.0 \
 		--webhook-config-server-port=$(WEBHOOK_CONFIG_PORT) \
 		--webhook-config-mode=$(WEBHOOK_CONFIG_MODE) \
+		--health-bind-address=:8082 \
+		--metrics-bind-address=:8083 \
         $(WEBHOOK_PARAM)
 
 #################################################################

--- a/charts/internal/falco/templates/falco-pod-template.tpl
+++ b/charts/internal/falco/templates/falco-pod-template.tpl
@@ -68,9 +68,6 @@ spec:
         {{- include "falco.securityContext" . | nindent 8 }}
       args:
         - /usr/bin/falco
-        {{- if and .Values.driver.enabled (eq .Values.driver.kind "modern-bpf") }}
-        - --modern-bpf
-        {{- end }}
         {{- if .Values.gvisor.enabled }}
         - --gvisor-config
         - /gvisor-config/pod-init.json

--- a/charts/internal/falco/values.yaml
+++ b/charts/internal/falco/values.yaml
@@ -434,6 +434,8 @@ falcoctl:
 # falco.yaml config  #
 ######################
 falco:
+
+
   #####################
   # Falco rules files #
   #####################
@@ -1431,6 +1433,17 @@ falco:
   # !!! The options mentioned here are not available in the falco.yaml
   # configuration file. Instead, they can can be used as a command-line argument
   # when running the Falco command.
+
+  #################################################
+  # Engine                                        #
+  #################################################
+
+  engine:
+    kind: modern_ebpf
+    modern_ebpf:
+      cpus_for_each_buffer: 2
+      buf_size_preset: 4
+      drop_failed_exit: false  
 
 ########################
 # Falcosidekick   #

--- a/cmd/gardener-extension-shoot-falco-service/app/app.go
+++ b/cmd/gardener-extension-shoot-falco-service/app/app.go
@@ -104,12 +104,12 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("could not instantiate manager: %w", err)
 			}
-			log.Info("Getting rest config for garden")
+			log.Info("getting rest config for garden")
 			gardenRESTConfig, err := kubernetes.RESTConfigFromKubeconfigFile(os.Getenv("GARDEN_KUBECONFIG"), kubernetes.AuthTokenFile)
 			if err != nil {
 				return err
 			}
-			log.Info("Setting up cluster object for garden")
+			log.Info("setting up cluster object for garden")
 			gardenCluster, err := cluster.New(gardenRESTConfig, func(opts *cluster.Options) {
 				opts.Scheme = kubernetes.GardenScheme
 				opts.Logger = log
@@ -117,7 +117,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("failed creating garden cluster object: %w", err)
 			}
-			log.Info("Adding garden cluster to manager")
+			log.Info("adding garden cluster to manager")
 			if err := mgr.Add(gardenCluster); err != nil {
 				return fmt.Errorf("failed adding garden cluster to manager: %w", err)
 			}

--- a/falco/falcoversions.yaml
+++ b/falco/falcoversions.yaml
@@ -6,3 +6,6 @@
   - version: 0.37.1
     classification: supported
     rulesVersion: 3.0.1
+  - version: 0.38.0
+    classification: supported
+    rulesVersion: 3.0.1

--- a/pkg/falcovalues/falcovalues.go
+++ b/pkg/falcovalues/falcovalues.go
@@ -122,12 +122,12 @@ func (c *ConfigBuilder) BuildFalcoValues(ctx context.Context, log logr.Logger, c
 			},
 		},
 		"falcocerts": map[string]interface{}{
-			"server_ca_crt": secrets.EncodeCertificate(cas.ServerCaCert),
-			"client_ca_crt": secrets.EncodeCertificate(cas.ClientCaCert),
-			"server_crt":    secrets.EncodeCertificate(certs.ServerCert),
-			"server_key":    secrets.EncodePrivateKey(certs.ServerKey),
-			"client_crt":    secrets.EncodeCertificate(certs.ClientCert),
-			"client_key":    secrets.EncodePrivateKey(certs.ClientKey),
+			"server_ca_crt": string(secrets.EncodeCertificate(cas.ServerCaCert)),
+			"client_ca_crt": string(secrets.EncodeCertificate(cas.ClientCaCert)),
+			"server_crt":    string(secrets.EncodeCertificate(certs.ServerCert)),
+			"server_key":    string(secrets.EncodePrivateKey(certs.ServerKey)),
+			"client_crt":    string(secrets.EncodeCertificate(certs.ClientCert)),
+			"client_key":    string(secrets.EncodePrivateKey(certs.ClientKey)),
 		},
 		"falco": map[string]interface{}{
 			"http_output": map[string]interface{}{
@@ -167,9 +167,9 @@ func (c *ConfigBuilder) BuildFalcoValues(ctx context.Context, log logr.Logger, c
 				"tlsserver": map[string]interface{}{
 					"deploy":        true,
 					"mutualtls":     false,
-					"server_key":    secrets.EncodePrivateKey(certs.ServerKey),
-					"server_crt":    secrets.EncodeCertificate(certs.ServerCert),
-					"server_ca_crt": secrets.EncodeCertificate(cas.ServerCaCert),
+					"server_key":    string(secrets.EncodePrivateKey(certs.ServerKey)),
+					"server_crt":    string(secrets.EncodeCertificate(certs.ServerCert)),
+					"server_ca_crt": string(secrets.EncodeCertificate(cas.ServerCaCert)),
 				},
 				"customfields": customFields,
 			},
@@ -177,7 +177,7 @@ func (c *ConfigBuilder) BuildFalcoValues(ctx context.Context, log logr.Logger, c
 		"customRules": customRules,
 	}
 
-	if falcoServiceConfig.CustomWebhook == nil {
+	if falcoServiceConfig.CustomWebhook == nil || falcoServiceConfig.CustomWebhook.Enabled != nil || !*falcoServiceConfig.CustomWebhook.Enabled {
 		// Gardener managed event store
 		ingestorAddress := c.config.Falco.IngestorURL
 		// ok to generate new token on each reconcile


### PR DESCRIPTION


**What this PR does / why we need it**:

- lowercase text messages
- allow to start extension and webhook server on same host
- work around a missing docker desktop feature on linux (host.docker.internal hostname)
- introduce falco version 0.38
- allow configuration to work with Falco 0.37.x and 0.38.x
- fixed bug putting certificates into secrets (double base64)
-
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
