### PR TITLE
Fix propagation of priority class name

### DIFF
--- a/charts/internal/falco/templates/falco-pod-template.tpl
+++ b/charts/internal/falco/templates/falco-pod-template.tpl
@@ -31,8 +31,8 @@ spec:
   dnsPolicy: ClusterFirstWithHostNet
   {{- end }}
   {{- end }}
-  {{- if .Values.podPriorityClassName }}
-  priorityClassName: {{ .Values.podPriorityClassName }}
+  {{- if .Values.priorityClassName }}
+  priorityClassName: {{ .Values.priorityClassName }}
   {{- end }}
   {{- with .Values.nodeSelector }}
   nodeSelector:

--- a/pkg/falcovalues/falcovalues.go
+++ b/pkg/falcovalues/falcovalues.go
@@ -158,7 +158,6 @@ func (c *ConfigBuilder) BuildFalcoValues(ctx context.Context, log logr.Logger, c
 			"image": map[string]string{
 				"image": falcosidekickImage,
 			},
-			"priorityClassName": c.config.Falco.PriorityClassName,
 			"config": map[string]interface{}{
 				"debug": true,
 				"tlsserver": map[string]interface{}{

--- a/pkg/falcovalues/falcovalues.go
+++ b/pkg/falcovalues/falcovalues.go
@@ -95,7 +95,7 @@ func (c *ConfigBuilder) BuildFalcoValues(ctx context.Context, log logr.Logger, c
 			{"effect": "NoSchedule", "operator": "Exists"},
 			{"effect": "NoExecute", "operator": "Exists"},
 		},
-		"priorityClassName": c.config.Falco.PriorityClassName,
+		"priorityClassName": *c.config.Falco.PriorityClassName,
 		"driver": map[string]string{
 			"kind": "modern-bpf",
 		},

--- a/pkg/falcovalues/falcovalues_test.go
+++ b/pkg/falcovalues/falcovalues_test.go
@@ -10,13 +10,6 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/gardener/gardener-extension-shoot-falco-service/charts"
-	"github.com/gardener/gardener-extension-shoot-falco-service/pkg/apis/config"
-	"github.com/gardener/gardener-extension-shoot-falco-service/pkg/apis/service"
-	apisservice "github.com/gardener/gardener-extension-shoot-falco-service/pkg/apis/service"
-	"github.com/gardener/gardener-extension-shoot-falco-service/pkg/constants"
-	"github.com/gardener/gardener-extension-shoot-falco-service/pkg/profile"
-	"github.com/gardener/gardener-extension-shoot-falco-service/pkg/secrets"
 	"github.com/gardener/gardener/extensions/pkg/util"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/chartrenderer"
@@ -31,8 +24,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
-
 	yaml "sigs.k8s.io/yaml"
+
+	"github.com/gardener/gardener-extension-shoot-falco-service/charts"
+	"github.com/gardener/gardener-extension-shoot-falco-service/pkg/apis/config"
+	"github.com/gardener/gardener-extension-shoot-falco-service/pkg/apis/service"
+	apisservice "github.com/gardener/gardener-extension-shoot-falco-service/pkg/apis/service"
+	"github.com/gardener/gardener-extension-shoot-falco-service/pkg/constants"
+	"github.com/gardener/gardener-extension-shoot-falco-service/pkg/profile"
+	"github.com/gardener/gardener-extension-shoot-falco-service/pkg/secrets"
 )
 
 var (

--- a/pkg/falcovalues/falcovalues_test.go
+++ b/pkg/falcovalues/falcovalues_test.go
@@ -10,6 +10,13 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/gardener/gardener-extension-shoot-falco-service/charts"
+	"github.com/gardener/gardener-extension-shoot-falco-service/pkg/apis/config"
+	"github.com/gardener/gardener-extension-shoot-falco-service/pkg/apis/service"
+	apisservice "github.com/gardener/gardener-extension-shoot-falco-service/pkg/apis/service"
+	"github.com/gardener/gardener-extension-shoot-falco-service/pkg/constants"
+	"github.com/gardener/gardener-extension-shoot-falco-service/pkg/profile"
+	"github.com/gardener/gardener-extension-shoot-falco-service/pkg/secrets"
 	"github.com/gardener/gardener/extensions/pkg/util"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/chartrenderer"
@@ -18,26 +25,20 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"helm.sh/helm/v3/pkg/releaseutil"
+	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	yaml "sigs.k8s.io/yaml/goyaml.v3"
 
-	"github.com/gardener/gardener-extension-shoot-falco-service/charts"
-	"github.com/gardener/gardener-extension-shoot-falco-service/pkg/apis/config"
-	"github.com/gardener/gardener-extension-shoot-falco-service/pkg/apis/service"
-	apisservice "github.com/gardener/gardener-extension-shoot-falco-service/pkg/apis/service"
-	"github.com/gardener/gardener-extension-shoot-falco-service/pkg/constants"
-	"github.com/gardener/gardener-extension-shoot-falco-service/pkg/profile"
-	"github.com/gardener/gardener-extension-shoot-falco-service/pkg/secrets"
+	yaml "sigs.k8s.io/yaml"
 )
 
 var (
 	extensionConfiguration = &config.Configuration{
 		Falco: &config.Falco{
-			PriorityClassName:     stringValue("falco-priority"),
+			PriorityClassName:     stringValue("falco-test-priority-dummy-classname"),
 			CertificateLifetime:   &metav1.Duration{Duration: constants.DefaultCertificateLifetime},
 			CertificateRenewAfter: &metav1.Duration{Duration: constants.DefaultCertificateRenewAfter},
 			TokenLifetime:         &metav1.Duration{Duration: constants.DefaultTokenLifetime},
@@ -67,7 +68,7 @@ var (
 		},
 		&map[string]profile.Image{
 			"0.38.0": {
-				Repository:   "falcosecurity/falco:0.38.0",
+				Repository:   "falcosecurity/falco",
 				Tag:          "0.38.0",
 				Architectrue: "amd64",
 				Version:      "0.38.0",
@@ -81,7 +82,7 @@ var (
 		},
 		&map[string]profile.Image{
 			"1.2.3": {
-				Repository:   "falcosecurity/falcosidekick:1,2,3",
+				Repository:   "falcosecurity/falcosidekick",
 				Tag:          "1.2.3",
 				Architectrue: "amd64",
 				Version:      "1.2.3",
@@ -296,6 +297,11 @@ var _ = Describe("Test value generation for helm chart", Label("falcovalues"), f
 		_, ok = values["falcoSandboxRules"]
 		Expect(ok).To(BeFalse())
 
+		prioriyClass := values["priorityClassName"].(string)
+		Expect(prioriyClass).To(Equal("falco-test-priority-dummy-classname"))
+
+		// render chart and check if the values are set correctly
+		//
 		renderer, err := util.NewChartRendererForShoot("1.30.2")
 		Expect(err).To(BeNil())
 		release, err := renderer.RenderEmbeddedFS(charts.InternalChart, filepath.Join(charts.InternalChartsPath, constants.FalcoChartname), constants.FalcoChartname, metav1.NamespaceSystem, values)
@@ -305,31 +311,39 @@ var _ = Describe("Test value generation for helm chart", Label("falcovalues"), f
 			fmt.Println(mf.Name + " " + mf.Head.Kind)
 			fmt.Println(mf.Content)
 		}
+
+		// check custom rules
 		customRules := getManifest(release, "falco/templates/falco-custom-rules.yaml")
 		Expect(customRules).NotTo(BeNil())
-		m := make(map[interface{}]interface{})
-
+		m := make(map[string]interface{})
 		falcoConfigmap := getManifest((release), "falco/templates/falco-configmap.yaml")
 		fc := corev1.ConfigMap{}
 		err = yaml.Unmarshal([]byte(falcoConfigmap.Content), &fc)
 		Expect(err).To(BeNil())
-		//		Expect(fc.Data["falco.yaml"]).To(ContainSubstring("- /etc/falco/rules.d/dummyrules.yaml"))
 		falcoYaml := make(map[string]interface{})
-
 		err = yaml.Unmarshal([]byte(fc.Data["falco.yaml"]), &falcoYaml)
 		Expect(err).To(BeNil())
 		rules := falcoYaml["rules_file"].([]interface{})
 		Expect(len(rules)).To(Equal(2))
 		Expect(rules[0]).To(Equal("/etc/falco/rules.d/falco_rules.yaml"))
 		Expect(rules[1]).To(Equal("/etc/falco/rules.d/dummyrules.yaml"))
-
+		fmt.Println(customRules.Content)
 		err = yaml.Unmarshal([]byte(customRules.Content), &m)
 		Expect(err).To(BeNil())
-
 		data := m["data"].(map[string]interface{})
 		rulesFile := data["dummyrules.yaml"].(string)
 		Expect(rulesFile).To(Equal("# dummy rules 1"))
 
+		// check priority class in falco deamonset
+		falcoDaemonset := getManifest(release, "falco/templates/falco-daemonset.yaml")
+		Expect(falcoDaemonset).NotTo(BeNil())
+		ds := appsv1.DaemonSet{}
+		fmt.Println(falcoDaemonset.Content)
+		err = yaml.Unmarshal([]byte(falcoDaemonset.Content), &ds)
+		Expect(err).To(BeNil())
+		Expect(ds.Spec.Template.Spec.Containers[0].Image).To(Equal("falcosecurity/falco:0.38.0"))
+		Expect(ds.Spec.Template.Spec.Containers[0].ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
+		Expect(ds.Spec.Template.Spec.PriorityClassName).To(Equal("falco-test-priority-dummy-classname"))
 		fmt.Println((customRules.Content))
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix propagation of priority class name. Falco daemonsets did not have a priority class name which causes some pods not to be launched on seeds.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
