### PR TITLE
Publish Helm charts as OCI artifacts

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -3,6 +3,27 @@
 # SPDX-License-Identifier: Apache-2.0
 
 gardener-extension-shoot-falco-service:
+  templates:
+    helmcharts:
+    - &shoot-falco-service
+      name: shoot-falco-service
+      dir: charts/gardener-extension-shoot-falco-service
+      registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
+      mappings:
+      - ref: ocm-resource:gardener-extension-shoot-falco-service.repository
+        attribute: image.repository
+      - ref: ocm-resource:gardener-extension-shoot-falco-service.tag
+        attribute: image.tag
+    - &shoot-falco-service-admission
+      name: admission-shoot-falco-service
+      dir: charts/gardener-extension-admission-shoot-falco-service
+      registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
+      mappings:
+      - ref: ocm-resource:gardener-extension-admission-shoot-falco-service.repository
+        attribute: global.image.repository
+      - ref: ocm-resource:gardener-extension-admission-shoot-falco-service.tag
+        attribute: global.image.tag
+
   base_definition:
     traits:
       component_descriptor:
@@ -37,6 +58,9 @@ gardener-extension-shoot-falco-service:
               image: europe-docker.pkg.dev/gardener-project/snapshots/gardener/extensions/admission-shoot-falco-service
               dockerfile: 'Dockerfile'
               target: gardener-extension-admission-shoot-falco-service
+          helmcharts:
+          - *shoot-falco-service
+          - *shoot-falco-service-admission
     pull-request:
       traits:
         pull-request: ~
@@ -72,3 +96,8 @@ gardener-extension-shoot-falco-service:
               image: europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/admission-shoot-falco-service
               tag_as_latest: true
               target: gardener-extension-admission-shoot-falco-service
+          helmcharts:
+          - <<: *shoot-falco-service
+            registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions
+          - <<: *shoot-falco-service-admission
+            registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions

--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -14,9 +14,18 @@ gardener-extension-shoot-falco-service:
         attribute: image.repository
       - ref: ocm-resource:gardener-extension-shoot-falco-service.tag
         attribute: image.tag
-    - &shoot-falco-service-admission
-      name: admission-shoot-falco-service
-      dir: charts/gardener-extension-admission-shoot-falco-service
+    - &shoot-falco-service-admission-application
+      name: admission-shoot-falco-service-application
+      dir: charts/gardener-extension-admission-shoot-falco-service/charts/application
+      registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
+      mappings:
+      - ref: ocm-resource:gardener-extension-admission-shoot-falco-service.repository
+        attribute: global.image.repository
+      - ref: ocm-resource:gardener-extension-admission-shoot-falco-service.tag
+        attribute: global.image.tag
+    - &shoot-falco-service-admission-runtime
+      name: admission-shoot-falco-service-runtime
+      dir: charts/gardener-extension-admission-shoot-falco-service/charts/runtime
       registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
       mappings:
       - ref: ocm-resource:gardener-extension-admission-shoot-falco-service.repository
@@ -60,7 +69,8 @@ gardener-extension-shoot-falco-service:
               target: gardener-extension-admission-shoot-falco-service
           helmcharts:
           - *shoot-falco-service
-          - *shoot-falco-service-admission
+          - *shoot-falco-service-admission-application
+          - *shoot-falco-service-admission-runtime
     pull-request:
       traits:
         pull-request: ~
@@ -99,5 +109,7 @@ gardener-extension-shoot-falco-service:
           helmcharts:
           - <<: *shoot-falco-service
             registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions
-          - <<: *shoot-falco-service-admission
+          - <<: *shoot-falco-service-admission-application
+            registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions
+          - <<: *shoot-falco-service-admission-runtime
             registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions


### PR DESCRIPTION
/area delivery
/kind enhancement

**What this PR does / why we need it**:
We should start publishing Helm charts as OCI artifacts that we can deploy them as `Extension` in the future (see https://github.com/gardener/gardener/issues/9635).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Helm charts of extension and admission controller are published as OCI artifacts now.
```
