### PR TITLE
Add preview flag to admission controller

### DIFF
--- a/charts/gardener-extension-admission-shoot-falco-service/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener-extension-admission-shoot-falco-service/charts/runtime/templates/deployment.yaml
@@ -53,10 +53,16 @@ spec:
         {{- end }}
         - --health-bind-address=:{{ .Values.global.healthPort }}
         - --leader-election-id={{ include "leaderelectionid" . }}
-        {{- if .Values.global.virtualGarden.enabled }}
+        {{- if or .Values.global.virtualGarden.enabled .Values.global.restrictedUsage }}
         env:
+        {{- if .Values.global.virtualGarden.enabled }}
         - name: SOURCE_CLUSTER
           value: enabled
+        {{- end }}
+        {{- if .Values.global.restrictedUsage }}
+        - name: RESTICTED_USAGE
+          value: true
+        {{- end }}
         {{- end }}
         ports:
         - name: webhook-server

--- a/charts/gardener-extension-admission-shoot-falco-service/values.yaml
+++ b/charts/gardener-extension-admission-shoot-falco-service/values.yaml
@@ -1,4 +1,5 @@
 global:
+  restrictedUsage: false
   virtualGarden:
     enabled: false
     user:

--- a/pkg/admission/validator/shoot_validator.go
+++ b/pkg/admission/validator/shoot_validator.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"slices"
 	"strconv"
 	"time"
@@ -57,8 +58,8 @@ func (s *shoot) validateShoot(_ context.Context, shoot *core.Shoot) error {
 		return err
 	}
 
-	alphaUsage := false
-	if alphaUsage {
+	alphaUsage, err := strconv.ParseBool(os.Getenv("RESTRICTED_USAGE"))
+	if err == nil && alphaUsage {
 		if ok := verifyProjectEligibility(shoot.Namespace); !ok {
 			return fmt.Errorf("project is not eligible for Falco extension")
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR added a way to configure the preview feature. It is disabled by default but can be enabled by setting the environment variable `RESTRICTED_USAGE` to `true`. 

If set, projects must have the annotation `falco.gardener.cloud/enabled=true` for adding falco to shoot clusters.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
