### PR TITLE
Removing the metadata_download configuration

### DIFF
--- a/charts/internal/falco/values.yaml
+++ b/charts/internal/falco/values.yaml
@@ -1382,30 +1382,6 @@ falco:
   # Falco cloud orchestration systems integration #
   #################################################
 
-  # [Stable] `metadata_download`
-  #
-  # -- When connected to an orchestrator like Kubernetes, Falco has the capability to
-  # collect metadata and enrich system call events with contextual data. The
-  # parameters mentioned here control the downloading process of this metadata.
-  #
-  # Please note that support for Mesos is deprecated, so these parameters
-  # currently apply only to Kubernetes. When using Falco with Kubernetes, you can
-  # enable this functionality by using the `-k` or `-K` command-line flag.
-  #
-  # However, it's worth mentioning that for important Kubernetes metadata fields
-  # such as namespace or pod name, these fields are automatically extracted from
-  # the container runtime, providing the necessary enrichment for common use cases
-  # of syscall-based threat detection.
-  #
-  # In summary, the `-k` flag is typically not required for most scenarios involving
-  # Kubernetes workload owner enrichment. The `-k` flag is primarily used when
-  # additional metadata is required beyond the standard fields, catering to more
-  # specific use cases, see https://falco.org/docs/reference/rules/supported-fields/#field-class-k8s.
-  metadata_download:
-    max_mb: 100
-    chunk_wait_us: 1000
-    watch_freq_sec: 1
-
   # [Stable] Guidance for Kubernetes container engine command-line args settings
   #
   # Modern cloud environments, particularly Kubernetes, heavily rely on


### PR DESCRIPTION
**What this PR does / why we need it**:

This functionality was removed in Falco 0.38 and now throws a warning during startup of Falco 0.39.1. This avoids the following message during Falco startup:

```
Fri Oct 18 05:04:34 2024:    /etc/falco/falco.yaml | schema validation: failed for <root>: Object contains a property that could not be validated using 'properties' or 'additionalProperties' constraints: 'metadata_download'.
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
