### PR TITLE
Support new falco version with new ruleset

### DIFF
--- a/falco/falco-profile.yaml
+++ b/falco/falco-profile.yaml
@@ -7,10 +7,6 @@ spec:
     falco:
     - architecture: amd64
       repository: falcosecurity/falco-distroless
-      tag: 0.37.0
-      version: 0.37.0
-    - architecture: amd64
-      repository: falcosecurity/falco-distroless
       tag: 0.37.1
       version: 0.37.1
     - architecture: amd64
@@ -46,23 +42,23 @@ spec:
   versions:
     falco:
     - classification: deprecated
-      expirationDate: '2024-05-20T23:59:59Z'
-      rulesVersion: 3.0.1
-      version: 0.37.0
-    - classification: deprecated
+      expirationDate: '2024-10-25T23:59:59Z'
       rulesVersion: 3.0.1
       version: 0.37.1
-    - classification: supported
+    - classification: deprecated
+      expirationDate: '2024-10-25T23:59:59Z'
       rulesVersion: 3.0.1
       version: 0.38.0
-    - classification: supported
+    - classification: deprecated
+      expirationDate: '2024-10-25T23:59:59Z'
       rulesVersion: 3.0.1
       version: 0.38.1
-    - classification: supported
+    - classification: deprecated
+      expirationDate: '2024-10-25T23:59:59Z'
       rulesVersion: 3.0.1
       version: 0.38.2
-    - classification: preview
-      rulesVersion: 3.0.1
+    - classification: supported
+      rulesVersion: 3.2.0
       version: 0.39.1
     falcoctl:
     - classification: supported

--- a/falco/falcoversions.yaml
+++ b/falco/falcoversions.yaml
@@ -1,23 +1,20 @@
   falcoVersions:
-  - version: 0.37.0
-    classification: deprecated
-    expirationDate: "2024-05-20T23:59:59Z"
-    rulesVersion: 3.0.1
   - version: 0.37.1
     classification: deprecated
-    expirationDate: "2024-11-01T23:59:59Z"
+    expirationDate: "2024-10-25T23:59:59Z"
     rulesVersion: 3.0.1
   - version: 0.38.0
     classification: deprecated
-    expirationDate: "2024-11-01T23:59:59Z"
+    expirationDate: "2024-10-25T23:59:59Z"
     rulesVersion: 3.0.1
   - version: 0.38.1
     classification: deprecated
-    expirationDate: "2024-11-01T23:59:59Z"
+    expirationDate: "2024-10-25T23:59:59Z"
     rulesVersion: 3.0.1
   - version: 0.38.2
-    classification: supported
+    classification: deprecated
+    expirationDate: "2024-10-25T23:59:59Z"
     rulesVersion: 3.0.1
   - version: 0.39.1
-    classification: preview
+    classification: supported
     rulesVersion: 3.2.0

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -30,20 +30,6 @@ images:
 - name: falco
   sourceRepository: https://github.com/falcosecurity/falco-distroless
   repository: falcosecurity/falco-distroless
-  tag: 0.37.0
-  version: 0.37.0
-  labels:
-    - name: 'gardener.cloud/cve-categorisation'
-      value:
-        network_exposure: 'private'
-        authentication_enforced: true
-        user_interaction: 'gardener-operator'
-        confidentiality_requirement: 'low'
-        integrity_requirement: 'low'
-        availability_requirement: 'low'
-- name: falco
-  sourceRepository: https://github.com/falcosecurity/falco-distroless
-  repository: falcosecurity/falco-distroless
   tag: 0.37.1
   version: 0.37.1
   labels:


### PR DESCRIPTION
**What this PR does / why we need it**:

Support now Falco version 0.39.1 and deprecate all older versions early.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Support new Falco version 039.1.
```
