### PR TITLE
Make /metrics endpoint available via http

### DIFF
--- a/charts/internal/falco/values.yaml
+++ b/charts/internal/falco/values.yaml
@@ -1591,7 +1591,7 @@ falcosidekick:
       # -- port to serve http server serving selected endpoints
       notlsport: 2810
       # -- a comma separated list of endpoints, if not empty, and tlsserver.deploy is true, a separate http server will be deployed for the specified endpoints (/ping endpoint needs to be notls for Kubernetes to be able to perform the healthchecks)
-      notlspaths: "/ping"
+      notlspaths: "/ping,/metrics,/healthz"
 
     loki:
       # -- Loki <http://host:port>, if not `empty`, Loki is *enabled*


### PR DESCRIPTION
**What this PR does / why we need it**:

It appears that we cannot easily scrape `/metrics` endpoints in shoots via https. This PR makes the `/metrics` endpoint of Falcosidekick available via http.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
