### PR TITLE
Set Falo version 0.39.2 as supported

### DIFF
--- a/falco/falco-profile.yaml
+++ b/falco/falco-profile.yaml
@@ -29,10 +29,10 @@ spec:
       version: 2.29.0
   versions:
     falco:
-    - classification: supported
+    - classification: deprecated
       rulesVersion: 3.2.0
       version: 0.39.1
-    - classification: preview
+    - classification: supported
       rulesVersion: 3.2.0
       version: 0.39.2
     falcoctl:

--- a/falco/falcoversions.yaml
+++ b/falco/falcoversions.yaml
@@ -1,7 +1,7 @@
   falcoVersions:
   - version: 0.39.1
-    classification: supported
+    classification: deprecated
     rulesVersion: 3.2.0
   - version: 0.39.2
-    classification: preview
+    classification: supported
     rulesVersion: 3.2.0


### PR DESCRIPTION
**What this PR does / why we need it**:

Falco versions < 0.39.2 do not work with Garden Linux 1592.3.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
