### PR TITLE
Add option to deploy falco-falcosidekick networkpolicy

### DIFF
--- a/charts/internal/falco/templates/falcosidekick-networkpolicy.yaml
+++ b/charts/internal/falco/templates/falcosidekick-networkpolicy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.falcosidekick.deployNetworkPolicies }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -17,3 +18,4 @@ spec:
       networking.gardener.cloud/to-falcosidekick: allowed
   policyTypes:
   - Egress
+{{- end }}

--- a/charts/internal/falco/templates/falcosidekick-networkpolicy.yaml
+++ b/charts/internal/falco/templates/falcosidekick-networkpolicy.yaml
@@ -18,4 +18,4 @@ spec:
       networking.gardener.cloud/to-falcosidekick: allowed
   policyTypes:
   - Egress
-{{- end }}
+{{- end }} 

--- a/charts/internal/falco/values.yaml
+++ b/charts/internal/falco/values.yaml
@@ -1365,7 +1365,8 @@ falcosidekick:
   # -- number of running pods
   replicaCount: 2
 
-  # Deploy networkplicy for communication between Falco and Falcosidekick 
+  # Deploy networkplicy for communication between Falco and Falcosidekick
+  # this required when deploying Falco in shoot clusters
   deployNetworkPolicies: true
 
   # -- number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)

--- a/charts/internal/falco/values.yaml
+++ b/charts/internal/falco/values.yaml
@@ -1365,6 +1365,9 @@ falcosidekick:
   # -- number of running pods
   replicaCount: 2
 
+  # Deploy networkplicy for communication between Falco and Falcosidekick 
+  deployNetworkPolicies: true
+
   # -- number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
   # revisionHistoryLimit: 1
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The network policy is needed / was needed in case network policies for the falco and falcosidekick pods are not fully managed by the gardener resource manager. We have a case now where the deployment of that network policy that was problematic and need a way to disable it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
