### PR TITLE
Fix glitch in shoot mutator

### DIFF
--- a/pkg/admission/mutator/shoot_mutator.go
+++ b/pkg/admission/mutator/shoot_mutator.go
@@ -59,15 +59,23 @@ func (s *Shoot) Mutate(ctx context.Context, new, _ client.Object) error {
 }
 
 func setOutput(falcoConf *service.FalcoServiceConfig) {
+	trueVal := true
+	falseVal := false
 	if falcoConf.Output == nil {
-		defaultLog := false
 		falcoConf.Output = &service.Output{
-			LogFalcoEvents: &defaultLog,
+			LogFalcoEvents: &trueVal,
 		}
 	}
 	if falcoConf.Output.EventCollector == nil {
 		defaultEventCollector := "central"
 		falcoConf.Output.EventCollector = &defaultEventCollector
+	}
+	if falcoConf.Output.LogFalcoEvents == nil {
+		if *falcoConf.Output.EventCollector != "none" {
+			falcoConf.Output.LogFalcoEvents = &falseVal
+		} else {
+			falcoConf.Output.LogFalcoEvents = &trueVal
+		}
 	}
 }
 

--- a/pkg/admission/mutator/shoot_mutator_test.go
+++ b/pkg/admission/mutator/shoot_mutator_test.go
@@ -246,6 +246,39 @@ var (
 		}
 	}`
 
+	mutate7 = `
+	{
+		"kind":"FalcoServiceConfig",
+		"apiVersion":"falco.extensions.gardener.cloud/v1alpha1",
+		"falcoVersion":"0.101.0",
+		"autoUpdate":false,
+		"resources":"gardener",
+		"gardener": {
+			"useFalcoSandboxRules":true
+		},
+		"output": {
+			"eventCollector":"cluster"
+		}
+	}`
+
+	expectedMutate7 = `
+	{
+		"kind":"FalcoServiceConfig",
+		"apiVersion":"falco.extensions.gardener.cloud/v1alpha1",
+		"falcoVersion":"0.101.0",
+		"autoUpdate":false,
+		"resources":"gardener",
+		"gardener": {
+			"useFalcoRules":true,
+			"useFalcoIncubatingRules":false,
+			"useFalcoSandboxRules":true
+		},
+		"output": {
+			"logFalcoEvents": false,
+			"eventCollector": "cluster"
+		}
+	}`
+
 	genericShoot = &gardencorev1beta1.Shoot{
 		Spec: gardencorev1beta1.ShootSpec{
 			Extensions: []gardencorev1beta1.Extension{
@@ -679,5 +712,10 @@ var _ = Describe("Test mutator", Label("mutator"), func() {
 		Expect(err).To(BeNil(), "Mutator failed", err)
 		result = genericShoot.Spec.Extensions[0].ProviderConfig.Raw
 		Expect(result).To(MatchJSON(expectedMutate6), "Mutator did not return expected result")
+
+		err = f(mutate7)
+		Expect(err).To(BeNil(), "Mutator failed", err)
+		result = genericShoot.Spec.Extensions[0].ProviderConfig.Raw
+		Expect(result).To(MatchJSON(expectedMutate7), "Mutator did not return expected result")
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

The extension panicked when output.logFalcoEvents was unset. Added test and fix.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
