### PR TITLE
Add compression capability for Falco custom rules

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/spf13/pflag v1.0.6
 	golang.org/x/mod v0.23.0
 	golang.org/x/tools v0.29.0
+	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.17.0
 	k8s.io/api v0.32.1
 	k8s.io/apimachinery v0.32.1
@@ -114,7 +115,6 @@ require (
 	google.golang.org/protobuf v1.36.4 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	istio.io/api v1.24.2 // indirect
 	istio.io/client-go v1.24.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/spf13/pflag v1.0.6
 	golang.org/x/mod v0.23.0
 	golang.org/x/tools v0.29.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.17.0
 	k8s.io/api v0.32.1
 	k8s.io/apimachinery v0.32.1
@@ -115,7 +115,7 @@ require (
 	google.golang.org/protobuf v1.36.4 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.12.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	istio.io/api v1.24.2 // indirect
 	istio.io/client-go v1.24.2 // indirect
 	k8s.io/apiextensions-apiserver v0.32.1 // indirect

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -54,6 +54,8 @@ const (
 	FalcoIncubatingRules = "falco-incubating_rules.yaml"
 	FalcoSandboxRules    = "falco-sandbox_rules.yaml"
 
+	CustomRulesMaxSize = 1048576 // 1 << 20 == 1MiB
+
 	ProjectEnableAnnotation = "falco.gardener.cloud/enabled"
 )
 

--- a/pkg/values/falcovalues.go
+++ b/pkg/values/falcovalues.go
@@ -584,10 +584,10 @@ func (c *ConfigBuilder) loadRuleConfig(ctx context.Context, log logr.Logger, nam
 			ruleFilesBinaryData[name] = file
 		}
 	}
-	return loadRulesFromRulesFiles(ruleFilesData, ruleFilesBinaryData)
+	return extractRulesFromRulesFiles(ruleFilesData, ruleFilesBinaryData)
 }
 
-func loadRulesFromRulesFiles(ruleFilesData map[string]string, ruleFilesBinaryData map[string][]byte) ([]customRulesFile, error) {
+func extractRulesFromRulesFiles(ruleFilesData map[string]string, ruleFilesBinaryData map[string][]byte) ([]customRulesFile, error) {
 	rules := make([]customRulesFile, 0)
 	for name, content := range ruleFilesData {
 		if err := validateYaml(content); err != nil {

--- a/pkg/values/falcovalues.go
+++ b/pkg/values/falcovalues.go
@@ -602,7 +602,7 @@ func loadRulesFromRulesFiles(ruleFilesData map[string]string, ruleFilesBinaryDat
 	}
 
 	for name, content := range ruleFilesBinaryData {
-		dataGz := make([]byte, 0)
+		dataGz := make([]byte, base64.StdEncoding.DecodedLen(len(content)))
 		_, err := base64.StdEncoding.Decode(dataGz, content)
 		if err != nil {
 			return nil, fmt.Errorf("rule file has .gz type but data is not base64 encoded: %v", err)

--- a/pkg/values/falcovalues.go
+++ b/pkg/values/falcovalues.go
@@ -606,6 +606,8 @@ func loadRulesFromRulesFiles(ruleFilesData map[string]string, ruleFilesBinaryDat
 			return nil, fmt.Errorf("failed to decompress rule file %s: %v", name, err)
 		}
 
+		name = strings.TrimSuffix(name, ".gz")
+
 		if err := validateYaml(rawData); err != nil {
 			return nil, fmt.Errorf("rule file %s is not valid yaml: %v", name, err)
 		}

--- a/pkg/values/falcovalues.go
+++ b/pkg/values/falcovalues.go
@@ -575,7 +575,6 @@ func (c *ConfigBuilder) loadRuleConfig(ctx context.Context, log logr.Logger, nam
 
 func loadRulesFromRulesFiles(ruleFiles map[string]string) ([]customRulesFile, error) {
 	rules := make([]customRulesFile, len(ruleFiles))
-	i := 0
 	for name, content := range ruleFiles {
 		// check if name has gzip ending
 		if name[len(name)-3:] == ".gz" {
@@ -590,11 +589,10 @@ func loadRulesFromRulesFiles(ruleFiles map[string]string) ([]customRulesFile, er
 			}
 		}
 
-		rules[i] = customRulesFile{
+		rules = append(rules, customRulesFile{
 			Filename: name,
 			Content:  content,
-		}
-		i++
+		})
 	}
 	slices.SortFunc(rules, func(a, b customRulesFile) int {
 		return strings.Compare(a.Filename, b.Filename)

--- a/pkg/values/falcovalues.go
+++ b/pkg/values/falcovalues.go
@@ -19,7 +19,7 @@ import (
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/go-logr/logr"
 	"golang.org/x/mod/semver"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/values/falcovalues.go
+++ b/pkg/values/falcovalues.go
@@ -684,7 +684,7 @@ func checkUncompressedSize(datagz []byte) (uint32, error) {
 		return 0, err
 	}
 
-	if isize > 1<<20 { // gzip is using base2 -> 1MiB
+	if isize > constants.CustomRulesMaxSize {
 		return 0, fmt.Errorf("uncompressed size is larger than 1 MiB: %d bytes", isize)
 	}
 

--- a/pkg/values/falcovalues.go
+++ b/pkg/values/falcovalues.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"encoding/base64"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -551,8 +550,8 @@ func (c *ConfigBuilder) getCustomRules(ctx context.Context, log logr.Logger, clu
 }
 
 func (c *ConfigBuilder) loadRuleConfig(ctx context.Context, log logr.Logger, namespace string, selectedConfigMaps map[string]string) ([]customRulesFile, error) {
-	ruleFilesData := map[string]string{}
-	ruleFilesBinaryData := map[string][]byte{}
+	ruleFilesData := make(map[string]string)
+	ruleFilesBinaryData := make(map[string][]byte)
 	for ruleRef, configMapName := range selectedConfigMaps {
 		log.Info("loading custom rule", "ruleRef", ruleRef, "configMapName", configMapName)
 		configMap := corev1.ConfigMap{}
@@ -602,13 +601,7 @@ func loadRulesFromRulesFiles(ruleFilesData map[string]string, ruleFilesBinaryDat
 	}
 
 	for name, content := range ruleFilesBinaryData {
-		dataGz := make([]byte, base64.StdEncoding.DecodedLen(len(content)))
-		_, err := base64.StdEncoding.Decode(dataGz, content)
-		if err != nil {
-			return nil, fmt.Errorf("rule file has .gz type but data is not base64 encoded: %v", err)
-		}
-
-		rawData, err := decompressRulesFile(dataGz)
+		rawData, err := decompressRulesFile(content)
 		if err != nil {
 			return nil, fmt.Errorf("failed to decompress rule file %s: %v", name, err)
 		}

--- a/pkg/values/falcovalues.go
+++ b/pkg/values/falcovalues.go
@@ -658,7 +658,7 @@ func decompressRulesFile(datagz []byte) (string, error) {
 
 	isize, err := checkUncompressedSize(datagz)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	// Create a LimitedReader to limit the number of bytes read to isize

--- a/pkg/values/falcovalues.go
+++ b/pkg/values/falcovalues.go
@@ -658,7 +658,7 @@ func decompressRulesFile(datagz []byte) (string, error) {
 
 	isize, err := checkUncompressedSize(datagz)
 	if err != nil {
-		return nil, err
+		return "", err
 	}
 
 	// Create a LimitedReader to limit the number of bytes read to isize

--- a/pkg/values/falcovalues.go
+++ b/pkg/values/falcovalues.go
@@ -566,7 +566,7 @@ func (c *ConfigBuilder) loadRuleConfig(ctx context.Context, log logr.Logger, nam
 			return nil, fmt.Errorf("failed to get custom rule configmap %s (resource %s): %w", refConfigMapName, ruleRef, err)
 		}
 		for name, file := range configMap.Data {
-			if !strings.HasSuffix("name", ".yaml") {
+			if !strings.HasSuffix(name, ".yaml") {
 				return nil, fmt.Errorf("rule file %s is not a yaml file", name)
 			}
 			if _, ok := ruleFilesData[name]; ok {
@@ -576,7 +576,7 @@ func (c *ConfigBuilder) loadRuleConfig(ctx context.Context, log logr.Logger, nam
 		}
 
 		for name, file := range configMap.BinaryData {
-			if !strings.HasSuffix("name", ".yaml.gz") {
+			if !strings.HasSuffix(name, ".yaml.gz") {
 				return nil, fmt.Errorf("rule file %s is not a gzipped yaml file", name)
 			}
 			if _, ok := ruleFilesBinaryData[name]; ok {

--- a/pkg/values/falcovalues.go
+++ b/pkg/values/falcovalues.go
@@ -631,8 +631,11 @@ func decompressRulesFile(data64gz string) (string, error) {
 		return "", err
 	}
 
-	data := make([]byte, isize, isize)
-	_, err = reader.Read(data) // Read the entire compressed data
+	// Create a LimitedReader to limit the number of bytes read to isize
+	limitedReader := io.LimitedReader{R: reader, N: int64(isize)}
+
+	data := make([]byte, 0)
+	_, err = io.ReadFull(&limitedReader, data) // Read the entire compressed data
 	if err != nil {
 		return "", fmt.Errorf("failed to read gzipped data: %v", err)
 	}

--- a/pkg/values/falcovalues_test.go
+++ b/pkg/values/falcovalues_test.go
@@ -8,7 +8,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -590,7 +589,7 @@ var _ = Describe("loadRulesFromRulesFiles", func() {
 		rules, err := loadRulesFromRulesFiles(nil, ruleFilesBinaryData)
 		Expect(err).To(BeNil())
 		Expect(len(rules)).To(Equal(1))
-		Expect(rules[0].Filename).To(Equal("rule1.yaml.gz"))
+		Expect(rules[0].Filename).To(Equal("rule1.yaml"))
 		Expect(rules[0].Content).To(Equal(falcoRuleYaml))
 	})
 
@@ -604,19 +603,6 @@ var _ = Describe("loadRulesFromRulesFiles", func() {
 		rules, err := loadRulesFromRulesFiles(nil, ruleFilesBinaryData)
 		Expect(err).NotTo(BeNil())
 		Expect(err.Error()).To(ContainSubstring("failed to decompress rule file"))
-		Expect(rules).To(BeNil())
-	})
-
-	It("should return an error for invalid gzip content", func() {
-		invalidGzipContent := base64.StdEncoding.EncodeToString([]byte("invalid_gzip_content"))
-
-		ruleFiles := map[string][]byte{
-			"rule1.yaml.gz": []byte(invalidGzipContent),
-		}
-
-		rules, err := loadRulesFromRulesFiles(nil, ruleFiles)
-		Expect(err).NotTo(BeNil())
-		Expect(err.Error()).To(ContainSubstring("failed to create gzip reader"))
 		Expect(rules).To(BeNil())
 	})
 
@@ -634,17 +620,17 @@ key1:
 		gz.Close()
 
 		ruleFilesBinaryData := map[string][]byte{
-			"rule1.yaml.gz": []byte(buf.Bytes()),
+			"rule1.yaml.gz": buf.Bytes(),
 		}
 
 		rules, err := loadRulesFromRulesFiles(nil, ruleFilesBinaryData)
 		Expect(err).NotTo(BeNil())
-		Expect(err.Error()).To(ContainSubstring("rule file rule1.yaml.gz is not valid yaml"))
+		Expect(err.Error()).To(ContainSubstring("rule file rule1.yaml is not valid yaml"))
 		Expect(rules).To(BeNil())
 	})
 
 	It("should load and sort rules from mixed valid rule files and gzipped content", func() {
-		// Create a gzip compressed content for rule3.yaml.gz
+		// Create a gzip compressed content for rule2.yaml.gz
 		var buf bytes.Buffer
 		gz := gzip.NewWriter(&buf)
 		_, err := gz.Write([]byte(falcoRuleYaml))
@@ -657,7 +643,7 @@ key1:
 		}
 
 		ruleFilesBinaryData := map[string][]byte{
-			"rule2.yaml.gz": []byte(buf.Bytes()),
+			"rule2.yaml.gz": buf.Bytes(),
 		}
 
 		rules, err := loadRulesFromRulesFiles(ruleFilesData, ruleFilesBinaryData)
@@ -665,7 +651,7 @@ key1:
 		Expect(len(rules)).To(Equal(3))
 		Expect(rules[0].Filename).To(Equal("rule1.yaml"))
 		Expect(rules[0].Content).To(Equal("valid_yaml_content_1"))
-		Expect(rules[1].Filename).To(Equal("rule2.yaml.gz"))
+		Expect(rules[1].Filename).To(Equal("rule2.yaml"))
 		Expect(rules[1].Content).To(Equal(falcoRuleYaml))
 		Expect(rules[2].Filename).To(Equal("rule3.yaml"))
 		Expect(rules[2].Content).To(Equal("valid_yaml_content_3"))

--- a/pkg/values/falcovalues_test.go
+++ b/pkg/values/falcovalues_test.go
@@ -565,7 +565,7 @@ var _ = Describe("loadRulesFromRulesFiles", func() {
 			"rule2.yaml": "valid_yaml_content_2",
 		}
 
-		rules, err := loadRulesFromRulesFiles(ruleFilesData, nil)
+		rules, err := extractRulesFromRulesFiles(ruleFilesData, nil)
 		Expect(err).To(BeNil())
 		Expect(len(rules)).To(Equal(2))
 		Expect(rules[0].Filename).To(Equal("rule1.yaml"))
@@ -586,7 +586,7 @@ var _ = Describe("loadRulesFromRulesFiles", func() {
 			"rule1.yaml.gz": buf.Bytes(),
 		}
 
-		rules, err := loadRulesFromRulesFiles(nil, ruleFilesBinaryData)
+		rules, err := extractRulesFromRulesFiles(nil, ruleFilesBinaryData)
 		Expect(err).To(BeNil())
 		Expect(len(rules)).To(Equal(1))
 		Expect(rules[0].Filename).To(Equal("rule1.yaml"))
@@ -600,7 +600,7 @@ var _ = Describe("loadRulesFromRulesFiles", func() {
 			"rule1.yaml.gz": invalidGzipContent,
 		}
 
-		rules, err := loadRulesFromRulesFiles(nil, ruleFilesBinaryData)
+		rules, err := extractRulesFromRulesFiles(nil, ruleFilesBinaryData)
 		Expect(err).NotTo(BeNil())
 		Expect(err.Error()).To(ContainSubstring("failed to decompress rule file"))
 		Expect(rules).To(BeNil())
@@ -623,7 +623,7 @@ key1:
 			"rule1.yaml.gz": buf.Bytes(),
 		}
 
-		rules, err := loadRulesFromRulesFiles(nil, ruleFilesBinaryData)
+		rules, err := extractRulesFromRulesFiles(nil, ruleFilesBinaryData)
 		Expect(err).NotTo(BeNil())
 		Expect(err.Error()).To(ContainSubstring("rule file rule1.yaml is not valid yaml"))
 		Expect(rules).To(BeNil())
@@ -646,7 +646,7 @@ key1:
 			"rule2.yaml.gz": buf.Bytes(),
 		}
 
-		rules, err := loadRulesFromRulesFiles(ruleFilesData, ruleFilesBinaryData)
+		rules, err := extractRulesFromRulesFiles(ruleFilesData, ruleFilesBinaryData)
 		Expect(err).To(BeNil())
 		Expect(len(rules)).To(Equal(3))
 		Expect(rules[0].Filename).To(Equal("rule1.yaml"))


### PR DESCRIPTION
**How to categorize this PR?**:

/kind enhancement

**What this PR does / why we need it**:
Add compression capabilities as described in #146 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Falco custom rules files may now be provided in compressed `gzip` format. Compressed rules files (`.gz` file extension) can be readily added to a Configmap and referenced in the usual way.
```
