### PR TITLE
Modify healthcheck to check the `ManagedResourceNameFalcoSeed`

### DIFF
--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -43,7 +43,7 @@ func RegisterHealthChecks(ctx context.Context, mgr manager.Manager, opts healthc
 		[]healthcheck.ConditionTypeToHealthCheck{
 			{
 				ConditionType: string(gardencorev1beta1.ShootObservabilityComponentsHealthy),
-				HealthCheck:   general.CheckManagedResource(constants.ManagedResourceNameFalco),
+				HealthCheck:   general.CheckManagedResource(constants.ManagedResourceNameFalcoSeed),
 			},
 		},
 		sets.New[gardencorev1beta1.ConditionType](),


### PR DESCRIPTION
**What this PR does / why we need it**:
The current check is obsolete since it's covered by gardenlet - the check introduced by this PR however is needed since it's not covered.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
