### PR TITLE
Improve custom rule handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,17 +148,22 @@ test-cov:
 test-clean:
 	@bash $(GARDENER_HACK_DIR)/test-cover-clean.sh
 
-.PHONY: verify
-verify: check format test sast
 
 .PHONY: generate-profile
 generate-profile:
 	@$(HACK_DIR)/generate-falco-profile  imagevector/images.yaml falco/falcoversions.yaml falco/falcosidekickversions.yaml falco/falcoctlversions.yaml >falco/falco-profile.yaml
 
+.PHON: validate-imagevector
+validate-imagevector:
+	@$(HACK_DIR)/validate-imagevector.py imagevector/images.yaml
+
 .PHONY: validate-falco-rules
 validate-falco-rules:
 	$(HACK_DIR)/validate-falco-rules falco/falco-profile.yaml falco/rules
 
+.PHONY: verify
+verify: check format test sast validate-imagevector
+
 .PHONY: verify-extended
-verify-extended: check-generate check format generate-profile test sast-report
+verify-extended: check-generate check format validate-imagevector generate-profile test sast-report
 #verify-extended: check-generate check format test test-cov test-clean

--- a/hack/validate-falco-rules
+++ b/hack/validate-falco-rules
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener contributors
+# SPDX-FileCopyrightText: 2021 SAP SE or an SAP affiliate company and Gardener
+# contributors
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -8,16 +9,7 @@ import os
 import sys
 import yaml
 import tempfile
-import shutil
 import subprocess
-import time
-import dockerutil
-
-# usage: generate-falco-profile <imagevector> <falco-versions> <falcosidekick-versions> 
-
-# def get_rule_versions(falco_profile):
-#     rule_versions = {}
-#     for fv in falco_profile["spec"]["versions"]["falco"]
 
 
 falcoyaml = """
@@ -30,21 +22,22 @@ program_output:
   keep_alive: false
   program: 'jq ''{text: .output}'' | curl -d @- -X POST https://hooks.slack.com/services/XXX'
 rule_matching: first
-rules_files:
-- /etc/falco/falco_rules.yaml
-- /etc/falco/falco-incubating_rules.yaml
-- /etc/falco/falco-sandbox_rules.yaml
 stdout_output:
   enabled: true
-syscall_buf_size_preset: 4
 time_format_iso_8601: false
 watch_config_files: true
 webserver:
   enabled: false
 """
 
+
 def ci_init():
-    dockerutil.launch_dockerd_if_not_running()
+    try:
+        import dockerutil
+        dockerutil.launch_dockerd_if_not_running()
+    except ImportError:
+        print("assumme we are not runing in CI environment")
+
 
 def get_image_for_falco_version(falco_profile, version):
     for im in falco_profile["spec"]["images"]["falco"]:
@@ -53,14 +46,20 @@ def get_image_for_falco_version(falco_profile, version):
     sys.stderr.write(f"no image for Falco version {version}\n")
     sys.exit(1)
 
+
 def load_rules(rules_dir, rules_version):
-    files = ["falco_rules.yaml", "falco-incubating_rules.yaml", "falco-sandbox_rules.yaml"]
+    files = [
+        "falco_rules.yaml", 
+        "falco-incubating_rules.yaml", 
+        "falco-sandbox_rules.yaml"
+        ]
     rules = {}
     for file in files:
         filename = os.path.join(rules_dir, rules_version, file)
         with open(filename) as f:
             rules[file] = f.read()
     return rules
+
 
 def build_config_dir(rules_files):
     temp_dir = tempfile.TemporaryDirectory()
@@ -75,10 +74,13 @@ def build_config_dir(rules_files):
             f.write(v)
     return temp_dir
 
+
 def run_validate(config_dir, repo, tag):
     print("Validating rules for " + repo + ":" + tag)
     res = subprocess.run([
-        "docker", "run", "-t", "-v", config_dir.name + ":/etc/falco", repo + ":" + tag,
+        "docker", "run", "-t", "-v",
+        config_dir.name + ":/etc/falco", 
+        repo + ":" + tag,
         "falco", "-c", "/etc/falco/falco.yaml", 
         "--validate", "/etc/falco/falco_rules.yaml", 
         "--validate", "/etc/falco/falco-incubating_rules.yaml",
@@ -89,6 +91,7 @@ def run_validate(config_dir, repo, tag):
     else:
         return False
 
+
 def validate_rules(falco_profile, rules_dir, falco_version, rules_version):
     rules_files = load_rules(rules_dir, rules_version)
     config_dir = build_config_dir(rules_files)
@@ -96,23 +99,31 @@ def validate_rules(falco_profile, rules_dir, falco_version, rules_version):
     return run_validate(config_dir, repo, tag)
 
 
-if len(sys.argv) != 3:
-    sys.stderr.write("usage: validate-falco-rules <falco-profile> <rules-dir>\n")
-    sys.exit(1)
+def main():
+    if len(sys.argv) != 3:
+        sys.stderr.write(
+            "usage: validate-falco-rules <falco-profile> <rules-dir>\n"
+            )
+        sys.exit(1)
 
-ci_init()
+    with open(sys.argv[1]) as f:
+        falco_profile = yaml.safe_load(f)
 
-with open(sys.argv[1]) as f:
-    falco_profile = yaml.safe_load(f)
+    rules_dir = sys.argv[2]
 
-rules_dir = sys.argv[2]
+    has_error = False
+    for fv in falco_profile["spec"]["versions"]["falco"]:
+        has_error |= validate_rules(
+            falco_profile, rules_dir,
+            fv["version"], fv["rulesVersion"]
+        )
+    if has_error:
+        sys.stderr.write("At least one rule file has errors.\n")
+        sys.exit(1)
+    else:
+        sys.exit(0)
 
-has_error = False
-for fv in falco_profile["spec"]["versions"]["falco"]:
-    has_error |= validate_rules(falco_profile, rules_dir, fv["version"], fv["rulesVersion"])
 
-if has_error:
-    sys.stderr.write("At least one rule file has errors.\n")
-    sys.exit(1)
-else:
-    sys.exit(0)
+if __name__ == "__main__":
+    ci_init()
+    main()

--- a/hack/validate-imagevector.py
+++ b/hack/validate-imagevector.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+
+import sys
+import yaml
+import urllib.request
+
+"""
+Verify whehter images are available on docker hub
+"""
+
+
+def check_image(repository: str, tag: str, name: str) -> bool:
+    
+    url = f"https://hub.docker.com/v2/repositories/{repository}/tags/{tag}/"
+    try:
+        response = urllib.request.urlopen(url)
+        return response.status == 200
+    except urllib.error.HTTPError as e:
+        sys.stderr.write(f"Error checking image {repository}:{tag}: {e}\n")
+        return False
+
+
+def check_images(images: dict):
+    has_error = False
+    for image in images:
+        if not check_image(image["repository"], image["tag"], image["name"]):
+            print(f"Image {image['repository']}:{image['tag']} not found")
+            has_error = True
+        else:
+            print(f"Image {image['repository']}:{image['tag']} found")
+    return has_error
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.stderr.write("usage: verify-falco-images.py <imagevector>")
+        sys.exit(1)
+    with open(sys.argv[1], "r") as f:
+        iv = yaml.safe_load(f)
+    has_error = check_images(iv["images"])
+    if has_error:
+        sys.stderr.write("Not all images found\n")
+        sys.exit(1)
+    else:
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -57,6 +57,9 @@ const (
 	CustomRulesMaxSize = 1048576 // 1 << 20 == 1MiB
 
 	ProjectEnableAnnotation = "falco.gardener.cloud/enabled"
+
+	// limit the number of rule files with custom rules per config map
+	MaxCustomRulesFilesPerConfigMap = 10
 )
 
 var (

--- a/pkg/values/falcovalues_test.go
+++ b/pkg/values/falcovalues_test.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -57,6 +58,28 @@ var (
 		},
 		Output: &service.Output{
 			EventCollector: stringValue("central"),
+		},
+	}
+	shootExtensionManyCustomRules = &service.FalcoServiceConfig{
+		FalcoVersion: stringValue("0.38.0"),
+		Resources:    stringValue("gardener"),
+		Gardener: &service.Gardener{
+			UseFalcoRules: boolValue(true),
+			CustomRules:   []string{"rulesm2", "rulesm3", "rulesm1"},
+		},
+		Output: &service.Output{
+			EventCollector: stringValue("central"),
+		},
+	}
+	shootExtensionTooManyCustomRuleFiles = &service.FalcoServiceConfig{
+		FalcoVersion: stringValue("0.38.0"),
+		Resources:    stringValue("gardener"),
+		Gardener: &service.Gardener{
+			UseFalcoRules: boolValue(true),
+			CustomRules:   []string{"too-many-rule-files"},
+		},
+		Output: &service.Output{
+			EventCollector: stringValue("cluster"),
 		},
 	}
 	shootExtensionFalcoctl = &service.FalcoServiceConfig{
@@ -153,6 +176,38 @@ var (
 							APIVersion: "v1",
 						},
 					},
+					{
+						Name: "rulesm2",
+						ResourceRef: autoscalingv1.CrossVersionObjectReference{
+							Kind:       "ConfigMap",
+							Name:       "rulesm2",
+							APIVersion: "v1",
+						},
+					},
+					{
+						Name: "rulesm3",
+						ResourceRef: autoscalingv1.CrossVersionObjectReference{
+							Kind:       "ConfigMap",
+							Name:       "arulesm3",
+							APIVersion: "v1",
+						},
+					},
+					{
+						Name: "rulesm1",
+						ResourceRef: autoscalingv1.CrossVersionObjectReference{
+							Kind:       "ConfigMap",
+							Name:       "rulesm1",
+							APIVersion: "v1",
+						},
+					},
+					{
+						Name: "too-many-rule-files",
+						ResourceRef: autoscalingv1.CrossVersionObjectReference{
+							Kind:       "ConfigMap",
+							Name:       "too-many-rule-files",
+							APIVersion: "v1",
+						},
+					},
 				},
 			},
 			Status: gardencorev1beta1.ShootStatus{
@@ -234,9 +289,123 @@ var (
 					"dummyrules-other.yaml": "# dummy rules 3",
 				},
 			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "shoot--test--foo",
+					Name:      "ref-rulesm1",
+				},
+				Data: map[string]string{
+					"dummyrulesm1-1.yaml": "# dummy rules m1-1",
+					"dummyrulesm1-2.yaml": "# dummy rules m1-2",
+					"a-rules.yaml":        "# dummy rules m1-3",
+					"1-rules.yaml":        "# dummy rules m1-4",
+				},
+				BinaryData: map[string][]byte{
+					"edummyrulesm1-3.yaml.gz": decode("H4sICH1rs2cAA3J1bGVjLnlhbWwAU1ZIzs8tKEotLk5NUSgqzUlVMOQCABv4YJ8UAAAA"),
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "shoot--test--foo",
+					Name:      "ref-rulesm2",
+				},
+				Data: map[string]string{
+					"brules-m2-1.yaml":    "# dummy rules m2-1",
+					"dummyrulesm2.2.yaml": "# dummy rules 2",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "shoot--test--foo",
+					Name:      "ref-arulesm3",
+				},
+				Data: map[string]string{
+					"dummyrulesm3-1.yaml":  "# dummy rules m3-1",
+					"zdummyrulesm3-2.yaml": "# dummy rules m3-2",
+					"adummyrulesm3-3.yaml": "# dummy rules m3-3",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "shoot--test--foo",
+					Name:      "ref-too-many-rule-files",
+				},
+				Data: map[string]string{
+					"rules1.yaml":  "dummy rules 1",
+					"rules2.yaml":  "dummy rules 2",
+					"rules3.yaml":  "dummy rules 3",
+					"rules4.yaml":  "dummy rules 4",
+					"rules5.yaml":  "dummy rules 5",
+					"rules6.yaml":  "dummy rules 6",
+					"rules7.yaml":  "dummy rules 7",
+					"rules8.yaml":  "dummy rules 8",
+					"rules9.yaml":  "dummy rules 9",
+					"rules10.yaml": "dummy rules 10",
+					"rules11.yaml": "dummy rules 11",
+					"rules12.yaml": "dummy rules 12",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "shoot--test--foo",
+					Name:      "ref-test1",
+				},
+				Data: map[string]string{
+					"rule1.yaml": "valid_yaml_content_1",
+					"rule2.yaml": "valid_yaml_content_2",
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "shoot--test--foo",
+					Name:      "ref-invalidgzip",
+				},
+				BinaryData: map[string][]byte{
+					"broken.yaml.gz": []byte("this is not gzipped"),
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "shoot--test--foo",
+					Name:      "ref-correctyamlingzip",
+				},
+				BinaryData: map[string][]byte{
+					"correct-yaml-in.gip.yaml.gz": zip(`
+key1:
+
+			subkey1: value1
+			subkey2: value2`),
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "shoot--test--foo",
+					Name:      "ref-brokenyamlingzip",
+				},
+				BinaryData: map[string][]byte{
+					"broken-yaml-in.gip.yaml.gz": zip(`
+key1:
+
+			 subkey1: value1
+			subkey2: value2  # Incorrect indentation`),
+				},
+			},
 		},
 	}
 )
+
+func decode(encoded string) []byte {
+	data, _ := base64.StdEncoding.DecodeString(encoded)
+	return data
+}
+
+func zip(data string) []byte {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	gz.Write([]byte(data))
+	gz.Close()
+	return buf.Bytes()
+}
 
 var _ = Describe("Test value generation for helm chart", Label("falcovalues"), func() {
 
@@ -252,8 +421,8 @@ var _ = Describe("Test value generation for helm chart", Label("falcovalues"), f
 		res, err := configBuilder.extractCustomRules(shootSpec, falcoServiceConfig)
 		Expect(err).To(BeNil())
 		Expect(len(res)).To(Equal(2))
-		Expect(res).To(HaveKey("rules1"))
-		Expect(res).To(HaveKey("rules3"))
+		Expect(res[0].RefName).To(Equal("rules1"))
+		Expect(res[1].RefName).To(Equal("rules3"))
 
 		_, err = configBuilder.extractCustomRules(shootSpec, falcoServiceConfigBad)
 		Expect(err).NotTo(BeNil())
@@ -262,18 +431,30 @@ var _ = Describe("Test value generation for helm chart", Label("falcovalues"), f
 	It("Test loading rules from configmap", func(ctx SpecContext) {
 		err := configBuilder.client.Get(context.TODO(), client.ObjectKey{Namespace: "shoot--test--foo", Name: "ref-rules1"}, &corev1.ConfigMap{})
 		Expect(err).To(BeNil())
-		selectedConfigs := map[string]string{
-			"rules1": "rules1",
-			"rules2": "rules2",
+		selectedConfigs := []customRuleRef{
+			{
+				RefName:       "rules1",
+				ConfigMapName: "rules1",
+			},
+			{
+				RefName:       "rules2",
+				ConfigMapName: "rules2",
+			},
 		}
 		res, err := configBuilder.loadRuleConfig(context.TODO(), logger, "shoot--test--foo", selectedConfigs)
 		Expect(err).NotTo(BeNil())
 		Expect(err.Error()).To(Equal("duplicate rule file dummyrules.yaml"))
 		Expect(res).To(BeNil())
 
-		selectedConfigs = map[string]string{
-			"rules1": "rules1",
-			"rules3": "rules3",
+		selectedConfigs = []customRuleRef{
+			{
+				RefName:       "rules1",
+				ConfigMapName: "rules1",
+			},
+			{
+				RefName:       "rules3",
+				ConfigMapName: "rules3",
+			},
 		}
 		res, err = configBuilder.loadRuleConfig(context.TODO(), logger, "shoot--test--foo", selectedConfigs)
 		Expect(err).To(BeNil())
@@ -294,6 +475,52 @@ var _ = Describe("Test value generation for helm chart", Label("falcovalues"), f
 		Expect(res).To(ContainElement(cr2))
 		Expect(res).NotTo(ContainElement(cr3))
 
+	})
+
+	It("Test loading many rules from configmap preserving order", func(ctx SpecContext) {
+		values, err := configBuilder.BuildFalcoValues(context.TODO(), logger, shootSpec, "shoot--test--foo", shootExtensionManyCustomRules)
+		Expect(err).To(BeNil())
+		js, err := json.MarshalIndent((values), "", "    ")
+		Expect(err).To(BeNil())
+		Expect(len(js)).To(BeNumerically(">", 100))
+		cr := values["customRules"].([]customRulesFile)
+		Expect(len(cr)).To(Equal(10))
+		Expect(cr[0].Filename).To(Equal("brules-m2-1.yaml"))
+		Expect(cr[0].Content).To(Equal("# dummy rules m2-1"))
+		Expect(cr[1].Filename).To(Equal("dummyrulesm2.2.yaml"))
+		Expect(cr[1].Content).To(Equal("# dummy rules 2"))
+
+		Expect(cr[2].Filename).To(Equal("adummyrulesm3-3.yaml"))
+		Expect(cr[2].Content).To(Equal("# dummy rules m3-3"))
+		Expect(cr[3].Filename).To(Equal("dummyrulesm3-1.yaml"))
+		Expect(cr[3].Content).To(Equal("# dummy rules m3-1"))
+		Expect(cr[4].Filename).To(Equal("zdummyrulesm3-2.yaml"))
+		Expect(cr[4].Content).To(Equal("# dummy rules m3-2"))
+
+		Expect(cr[5].Filename).To(Equal("1-rules.yaml"))
+		Expect(cr[5].Content).To(Equal("# dummy rules m1-4"))
+		Expect(cr[6].Filename).To(Equal("a-rules.yaml"))
+		Expect(cr[6].Content).To(Equal("# dummy rules m1-3"))
+		Expect(cr[7].Filename).To(Equal("dummyrulesm1-1.yaml"))
+		Expect(cr[7].Content).To(Equal("# dummy rules m1-1"))
+		Expect(cr[8].Filename).To(Equal("dummyrulesm1-2.yaml"))
+		Expect(cr[8].Content).To(Equal("# dummy rules m1-2"))
+		Expect(cr[9].Filename).To(Equal("edummyrulesm1-3.yaml"))
+		Expect(cr[9].Content).To(Equal("# compressed rule 1\n"))
+
+		frules := values["falcoRules"].(string)
+		Expect(len(frules)).To(BeNumerically(">", 1000))
+		_, ok := values["falcoIncubatingRules"]
+		Expect(ok).To(BeFalse())
+		_, ok = values["falcoSandboxRules"]
+		Expect(ok).To(BeFalse())
+
+	})
+
+	It("Test configmap with too many rule files", func(ctx SpecContext) {
+		_, err := configBuilder.BuildFalcoValues(context.TODO(), logger, shootSpec, "shoot--test--foo", shootExtensionTooManyCustomRuleFiles)
+		Expect(err).NotTo(BeNil())
+		Expect(err.Error()).To(Equal("too many custom rule files in configmap \"ref-too-many-rule-files\""))
 	})
 
 	It("Test custom webhook functionality", func(ctx SpecContext) {
@@ -559,13 +786,19 @@ var falcoRuleYaml = `
 `
 
 var _ = Describe("loadRulesFromRulesFiles", func() {
-	It("should load rules from valid rule files", func() {
-		ruleFilesData := map[string]string{
-			"rule1.yaml": "valid_yaml_content_1",
-			"rule2.yaml": "valid_yaml_content_2",
-		}
 
-		rules, err := extractRulesFromRulesFiles(ruleFilesData, nil)
+	BeforeEach(func() {
+		fakeclient := crfake.NewFakeClient(rulesConfigMap)
+		tokenIssuer, err := secrets.NewTokenIssuer(tokenIssuerPrivateKey, &metav1.Duration{Duration: constants.DefaultTokenLifetime})
+		Expect(err).To(BeNil())
+		configBuilder = NewConfigBuilder(fakeclient, tokenIssuer, extensionConfiguration, falcoProfileManager)
+		logger, _ = glogger.NewZapLogger(glogger.InfoLevel, glogger.FormatJSON)
+	})
+
+	It("should load rules from valid rule files", func() {
+
+		rf := map[string]bool{}
+		rules, err := configBuilder.loadRulesFromConfigmap(context.TODO(), logger, rf, "shoot--test--foo", "test1")
 		Expect(err).To(BeNil())
 		Expect(len(rules)).To(Equal(2))
 		Expect(rules[0].Filename).To(Equal("rule1.yaml"))
@@ -574,87 +807,23 @@ var _ = Describe("loadRulesFromRulesFiles", func() {
 		Expect(rules[1].Content).To(Equal("valid_yaml_content_2"))
 	})
 
-	It("should decompress gzip content", func() {
-		// Create a gzip compressed content
-		var buf bytes.Buffer
-		gz := gzip.NewWriter(&buf)
-		_, err := gz.Write([]byte(falcoRuleYaml))
-		Expect(err).To(BeNil())
-		gz.Close()
-
-		ruleFilesBinaryData := map[string][]byte{
-			"rule1.yaml.gz": buf.Bytes(),
-		}
-
-		rules, err := extractRulesFromRulesFiles(nil, ruleFilesBinaryData)
-		Expect(err).To(BeNil())
-		Expect(len(rules)).To(Equal(1))
-		Expect(rules[0].Filename).To(Equal("rule1.yaml"))
-		Expect(rules[0].Content).To(Equal(falcoRuleYaml))
-	})
-
 	It("should return an error for invalid gzip content", func() {
-		invalidGzipContent := []byte("invalid_gzip_content")
 
-		ruleFilesBinaryData := map[string][]byte{
-			"rule1.yaml.gz": invalidGzipContent,
-		}
-
-		rules, err := extractRulesFromRulesFiles(nil, ruleFilesBinaryData)
+		rf := map[string]bool{}
+		rules, err := configBuilder.loadRulesFromConfigmap(context.TODO(), logger, rf, "shoot--test--foo", "invalidgzip")
 		Expect(err).NotTo(BeNil())
 		Expect(err.Error()).To(ContainSubstring("failed to decompress rule file"))
 		Expect(rules).To(BeNil())
 	})
 
 	It("should return an error for gzipped content that fails YAML validation", func() {
-		invalidYaml := `
-key1:
-  subkey1: value1
- subkey2: value2  # Incorrect indentation
-`
-		// Create a gzip compressed content
-		var buf bytes.Buffer
-		gz := gzip.NewWriter(&buf)
-		_, err := gz.Write([]byte(invalidYaml))
-		Expect(err).To(BeNil())
-		gz.Close()
 
-		ruleFilesBinaryData := map[string][]byte{
-			"rule1.yaml.gz": buf.Bytes(),
-		}
+		rf := map[string]bool{}
+		rules, err := configBuilder.loadRulesFromConfigmap(context.TODO(), logger, rf, "shoot--test--foo", "brokenyamlingzip")
 
-		rules, err := extractRulesFromRulesFiles(nil, ruleFilesBinaryData)
 		Expect(err).NotTo(BeNil())
-		Expect(err.Error()).To(ContainSubstring("rule file rule1.yaml is not valid yaml"))
+		Expect(err.Error()).To(ContainSubstring("rule file broken-yaml-in.gip.yaml.gz of configmap brokenyamlingzip is not valid yaml: data is not in valid yaml format: yaml: line 4: found character that cannot start any token"))
 		Expect(rules).To(BeNil())
-	})
-
-	It("should load and sort rules from mixed valid rule files and gzipped content", func() {
-		// Create a gzip compressed content for rule2.yaml.gz
-		var buf bytes.Buffer
-		gz := gzip.NewWriter(&buf)
-		_, err := gz.Write([]byte(falcoRuleYaml))
-		Expect(err).To(BeNil())
-		gz.Close()
-
-		ruleFilesData := map[string]string{
-			"rule3.yaml": "valid_yaml_content_3",
-			"rule1.yaml": "valid_yaml_content_1",
-		}
-
-		ruleFilesBinaryData := map[string][]byte{
-			"rule2.yaml.gz": buf.Bytes(),
-		}
-
-		rules, err := extractRulesFromRulesFiles(ruleFilesData, ruleFilesBinaryData)
-		Expect(err).To(BeNil())
-		Expect(len(rules)).To(Equal(3))
-		Expect(rules[0].Filename).To(Equal("rule1.yaml"))
-		Expect(rules[0].Content).To(Equal("valid_yaml_content_1"))
-		Expect(rules[1].Filename).To(Equal("rule2.yaml"))
-		Expect(rules[1].Content).To(Equal(falcoRuleYaml))
-		Expect(rules[2].Filename).To(Equal("rule3.yaml"))
-		Expect(rules[2].Content).To(Equal("valid_yaml_content_3"))
 	})
 })
 

--- a/pkg/values/falcovalues_test.go
+++ b/pkg/values/falcovalues_test.go
@@ -402,7 +402,10 @@ func decode(encoded string) []byte {
 func zip(data string) []byte {
 	var buf bytes.Buffer
 	gz := gzip.NewWriter(&buf)
-	gz.Write([]byte(data))
+	_, err := gz.Write([]byte(data))
+	if err != nil {
+		fmt.Println(err)
+	}
 	gz.Close()
 	return buf.Bytes()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix ordering of custom rules. The implementation did not match the documentation and the procedure stated in the documentation could not have been implemented, see release notes below. The number of possible rule files per configmap is now limited to 10.

Also added validation for images in imagevector.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Fixed the ordering for custom rules. Custom rules are now deployed in the following order: (1) in the oder they are referenced in the customRules key and (2) rule files in configmaps are sorted in alphanumerical order.
```
