### PR TITLE
Forbid container privilege escalations

### DIFF
--- a/charts/gardener-extension-admission-shoot-falco-service/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener-extension-admission-shoot-falco-service/charts/runtime/templates/deployment.yaml
@@ -85,6 +85,8 @@ spec:
         resources:
 {{ toYaml .Values.resources | nindent 10 }}
 {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         {{- if .Values.kubeconfig }}
         - name: gardener-extension-admission-shoot-falco-service-kubeconfig

--- a/charts/gardener-extension-shoot-falco-service/templates/deployment.yaml
+++ b/charts/gardener-extension-shoot-falco-service/templates/deployment.yaml
@@ -85,6 +85,8 @@ spec:
         resources:
 {{ toYaml .Values.resources | trim | indent 10 }}
         {{- end }}
+        securityContext:
+          allowPrivilegeEscalation: false
         volumeMounts:
         - name: extension-shoot-falco-service-config
           mountPath: /etc/extension-config

--- a/charts/internal/falco/values.yaml
+++ b/charts/internal/falco/values.yaml
@@ -78,7 +78,8 @@ podSecurityContext: {}
 #      - SYS_PTRACE
 #
 # -- Set securityContext for the Falco container.For more info see the "falco.securityContext" helper in "pod-template.tpl"
-containerSecurityContext: {}
+containerSecurityContext:
+  allowPrivilegeEscalation: false
 
 scc:
   # -- Create OpenShift's Security Context Constraint.

--- a/charts/internal/falco/values.yaml
+++ b/charts/internal/falco/values.yaml
@@ -78,8 +78,7 @@ podSecurityContext: {}
 #      - SYS_PTRACE
 #
 # -- Set securityContext for the Falco container.For more info see the "falco.securityContext" helper in "pod-template.tpl"
-containerSecurityContext:
-  allowPrivilegeEscalation: false
+containerSecurityContext: {}
 
 scc:
   # -- Create OpenShift's Security Context Constraint.
@@ -1391,7 +1390,8 @@ falcosidekick:
   fsGroup: 1234
 
   # -- Sidekick container securityContext
-  securityContext: {}
+  securityContext:
+    allowPrivilegeEscalation: false
 
   # One or more secrets to be used when pulling images
   # -- Secrets for the registry


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets the `securityContext.allowPrivilegeEscalation` field to `false` for every container, which does not have `securityContext.Privileged` set to `true` or one of `CAP_SYS_ADMIN/SYS_ADMIN` capabilities added.

**Which issue(s) this PR fixes**:
Part of gardener/gardener#11139

**Special notes for your reviewer**:
cc @AleksandarSavchev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Containers, which do not require privilege escalations, now forbid privilege escalations explicitly.
```