### PR TITLE
Drop support for Shoots with Kubernetes version <= 1.26

### DIFF
--- a/charts/gardener-extension-admission-shoot-falco-service/charts/runtime/templates/poddisruptionbudget.yaml
+++ b/charts/gardener-extension-admission-shoot-falco-service/charts/runtime/templates/poddisruptionbudget.yaml
@@ -10,6 +10,4 @@ spec:
   selector:
     matchLabels:
 {{ include "labels" . | indent 6 }}
-{{- if semverCompare ">= 1.26-0" .Capabilities.KubeVersion.GitVersion }}
   unhealthyPodEvictionPolicy: AlwaysAllow
-{{- end }}

--- a/charts/gardener-extension-admission-shoot-falco-service/charts/runtime/templates/service.yaml
+++ b/charts/gardener-extension-admission-shoot-falco-service/charts/runtime/templates/service.yaml
@@ -6,11 +6,7 @@ metadata:
   annotations:
     networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports: '[{"protocol":"TCP","port":{{ .Values.webhookConfig.serverPort }}}]'
     {{- if .Values.service.topologyAwareRouting.enabled }}
-    {{- if semverCompare ">= 1.27-0" .Capabilities.KubeVersion.GitVersion }}
     service.kubernetes.io/topology-mode: "auto"
-    {{- else }}
-    service.kubernetes.io/topology-aware-hints: "auto"
-    {{- end }}
     {{- end }}
   labels:
 {{ include "labels" . | indent 4 }}

--- a/hack/api-reference/config.json
+++ b/hack/api-reference/config.json
@@ -9,7 +9,7 @@
     "externalPackages": [
         {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
-            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         },
         {
             "typeMatchPrefix": "github.com/gardener/gardener/extensions/pkg/apis/config",

--- a/hack/api-reference/config.md
+++ b/hack/api-reference/config.md
@@ -45,7 +45,7 @@ string
 <td>
 <code>metadata</code></br>
 <em>
-<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#objectmeta-v1-meta">
+<a href="https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#objectmeta-v1-meta">
 Kubernetes meta/v1.ObjectMeta
 </a>
 </em>

--- a/hack/api-reference/service.json
+++ b/hack/api-reference/service.json
@@ -9,7 +9,7 @@
     "externalPackages": [
         {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
-            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
+            "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.32/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         },
         {
             "typeMatchPrefix": "github.com/gardener/gardener/extensions/pkg/apis/config",


### PR DESCRIPTION
**What this PR does / why we need it**:

- Adapt PDBs to use unhealthyPodEvictionPolicy: AlwaysAllow unconditionally
- Drop support for Shoots, Seeds and Gardens with Kubernetes version <= 1.26.
- Adapt service.kubernetes.io/topology-mode annotation

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/10339

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
`extension-shoot-falco-service` no longer supports Shoots with Кubernetes version <= 1.26.
```
