### PR TITLE
Fix empty extension spec

### DIFF
--- a/pkg/admission/mutator/shoot_mutator.go
+++ b/pkg/admission/mutator/shoot_mutator.go
@@ -228,9 +228,14 @@ func (s *Shoot) mutateShoot(_ context.Context, new *gardencorev1beta1.Shoot) err
 	if s.isDisabled(new) {
 		return nil
 	}
+
 	falcoConf, err := s.ExtractFalcoConfig(new)
 	if err != nil {
 		return err
+	}
+
+	if falcoConf == nil {
+		falcoConf = &service.FalcoServiceConfig{}
 	}
 
 	if err = setFalcoVersion(falcoConf); err != nil {

--- a/pkg/admission/mutator/shoot_mutator_test.go
+++ b/pkg/admission/mutator/shoot_mutator_test.go
@@ -760,8 +760,8 @@ var (
 		Spec: gardencorev1beta1.ShootSpec{
 			Extensions: []gardencorev1beta1.Extension{
 				{
-					Type:           "shoot-falco-service",
-					Disabled:       boolValue(false),
+					Type:     "shoot-falco-service",
+					Disabled: boolValue(false),
 				},
 			},
 		},

--- a/pkg/admission/mutator/shoot_mutator_test.go
+++ b/pkg/admission/mutator/shoot_mutator_test.go
@@ -45,7 +45,6 @@ var (
 		&map[string]profile.Image{},
 	)
 
-	// minimal
 	mutate1 = `
 	{
 		"kind":"FalcoServiceConfig",
@@ -757,6 +756,17 @@ var (
 		]
 	}`
 
+	genericEmptyConf = &gardencorev1beta1.Shoot{
+		Spec: gardencorev1beta1.ShootSpec{
+			Extensions: []gardencorev1beta1.Extension{
+				{
+					Type:           "shoot-falco-service",
+					Disabled:       boolValue(false),
+				},
+			},
+		},
+	}
+
 	genericShoot = &gardencorev1beta1.Shoot{
 		Spec: gardencorev1beta1.ShootSpec{
 			Extensions: []gardencorev1beta1.Extension{
@@ -1161,9 +1171,14 @@ var _ = Describe("Test mutator", Label("mutator"), func() {
 			return err
 		}
 
+		err = mutator.Mutate(context.TODO(), genericEmptyConf, nil)
+		Expect(err).To(BeNil(), "Mutator failed")
+		result := genericEmptyConf.Spec.Extensions[0].ProviderConfig.Raw
+		Expect(result).To(MatchJSON(expectedMutate1), "Mutator did not return expected result")
+
 		err = f(mutate1)
 		Expect(err).To(BeNil(), "Mutator failed")
-		result := genericShoot.Spec.Extensions[0].ProviderConfig.Raw
+		result = genericShoot.Spec.Extensions[0].ProviderConfig.Raw
 		Expect(result).To(MatchJSON(expectedMutate1), "Mutator did not return expected result")
 
 		err = f(mutate2)


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes a nil pointer dereference error for empty extension configs in the shoot spec

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
