### PR TITLE
Add an igress allow for traffic from falco to falcosidekick

### DIFF
--- a/charts/internal/falco/templates/falcosidekick-deployment.yaml
+++ b/charts/internal/falco/templates/falcosidekick-deployment.yaml
@@ -24,6 +24,7 @@ spec:
       labels:
         app.kubernetes.io/name: falcosidekick
         app.kubernetes.io/instance: {{ .Release.Name }}
+        networking.gardener.cloud/from-falco: allowed
       {{- if .Values.falcosidekick.podLabels }}
 {{ toYaml .Values.falcosidekick.podLabels | indent 8 }}
       {{- end }}

--- a/charts/internal/falco/templates/falcosidekick-networkpolicy.yaml
+++ b/charts/internal/falco/templates/falcosidekick-networkpolicy.yaml
@@ -19,5 +19,25 @@ spec:
       networking.gardener.cloud/to-falcosidekick: allowed
   policyTypes:
   - Egress
-{{- end }} 
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: gardener.cloud--allow-to-falcosidekick-ingress
+  namespace: {{ .Release.Namespace }}
+spec:
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app.kubernetes.io/name: falco
+    ports:
+    - port: 2801
+      protocol: TCP
+  podSelector:
+    matchLabels:
+      networking.gardener.cloud/from-falco: allowed
+  policyTypes:
+  - Ingress
+{{- end }}
 {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a allow ingress policy to falcosidekick for completion and to prepare for default deny

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add ingress network policy for future deny-all rule in kube-system namespace
```
