### PR TITLE
Add generation for `Extension` example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ endif
 # Tools                                 #
 #########################################
 
-TOOLS_DIR := hack/tools
+TOOLS_DIR := $(HACK_DIR)/tools
 include $(GARDENER_HACK_DIR)/tools.mk
 
 GO_MISSPELL := $(TOOLS_BIN_DIR)/misspell
@@ -141,9 +141,9 @@ generate-controller-registration:
 	@bash $(HACK_DIR)/generate-controller-registration.sh extension-shoot-falco charts/$(EXTENSION_PREFIX)-$(NAME) 0.0.1 example/ControllerRegistration.yaml
 
 .PHONY: generate
-generate: $(CONTROLLER_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(HELM) $(MOCKGEN) $(YQ) $(VGOPATH)
+generate: $(CONTROLLER_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(EXTENSION_GEN) $(HELM) $(MOCKGEN) $(KUSTOMIZE) $(YQ) $(VGOPATH)
 	@VGOPATH=$(VGOPATH) REPO_ROOT=$(REPO_ROOT) GARDENER_HACK_DIR=$(GARDENER_HACK_DIR) hack/update-codegen.sh
-	@VGOPATH=$(VGOPATH) REPO_ROOT=$(REPO_ROOT) GARDENER_HACK_DIR=$(GARDENER_HACK_DIR) bash $(GARDENER_HACK_DIR)/generate-sequential.sh ./charts/... ./cmd/... ./pkg/...
+	@VGOPATH=$(VGOPATH) REPO_ROOT=$(REPO_ROOT) GARDENER_HACK_DIR=$(GARDENER_HACK_DIR) bash $(GARDENER_HACK_DIR)/generate-sequential.sh ./charts/... ./cmd/... ./example/... ./pkg/...
 	@$(MAKE) format
 
 .PHONY: format

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,3 +1,6 @@
 *
+!/extension
+!doc.go
 !.gitignore
 !00-config.yaml.tmpl
+!extension.yaml

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,5 +1,6 @@
 *
-!/extension
+!extension/
+!extension/**
 !doc.go
 !.gitignore
 !00-config.yaml.tmpl

--- a/example/doc.go
+++ b/example/doc.go
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:generate sh -c "extension-generator --name=extension-shoot-falco-service --provider-type=shoot-falco-service --component-category=extension --extension-oci-repository=europe-docker.pkg.dev/gardener-project/public/charts/gardener/extensions/shoot-falco-service:$(cat ../VERSION) --admission-runtime-oci-repository=europe-docker.pkg.dev/gardener-project/public/charts/gardener/extensions/admission-shoot-falco-service-runtime:$(cat ../VERSION) --admission-application-oci-repository=europe-docker.pkg.dev/gardener-project/public/charts/gardener/extensions/admission-shoot-falco-service-application:$(cat ../VERSION) --destination=./extension/base/extension.yaml"
+//go:generate sh -c "$TOOLS_BIN_DIR/kustomize build ./extension -o ./extension.yaml"
+
+package example

--- a/example/extension.yaml
+++ b/example/extension.yaml
@@ -1,0 +1,25 @@
+apiVersion: operator.gardener.cloud/v1alpha1
+kind: Extension
+metadata:
+  annotations:
+    security.gardener.cloud/pod-security-enforce: baseline
+  name: extension-shoot-falco-service
+spec:
+  deployment:
+    admission:
+      runtimeCluster:
+        helm:
+          ociRepository:
+            ref: europe-docker.pkg.dev/gardener-project/public/charts/gardener/extensions/admission-shoot-falco-service-runtime:v0.74.0-dev
+      virtualCluster:
+        helm:
+          ociRepository:
+            ref: europe-docker.pkg.dev/gardener-project/public/charts/gardener/extensions/admission-shoot-falco-service-application:v0.74.0-dev
+    extension:
+      helm:
+        ociRepository:
+          ref: europe-docker.pkg.dev/gardener-project/public/charts/gardener/extensions/shoot-falco-service:v0.74.0-dev
+      injectGardenKubeconfig: true
+  resources:
+  - kind: Extension
+    type: shoot-falco-service

--- a/example/extension/base/extension.yaml
+++ b/example/extension/base/extension.yaml
@@ -1,8 +1,6 @@
 apiVersion: operator.gardener.cloud/v1alpha1
 kind: Extension
 metadata:
-  annotations:
-    security.gardener.cloud/pod-security-enforce: baseline
   name: extension-shoot-falco-service
 spec:
   deployment:
@@ -19,7 +17,6 @@ spec:
       helm:
         ociRepository:
           ref: europe-docker.pkg.dev/gardener-project/public/charts/gardener/extensions/shoot-falco-service:v0.76.0-dev
-      injectGardenKubeconfig: true
   resources:
   - kind: Extension
     type: shoot-falco-service

--- a/example/extension/base/kustomization.yaml
+++ b/example/extension/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- extension.yaml

--- a/example/extension/extension.yaml
+++ b/example/extension/extension.yaml
@@ -1,0 +1,10 @@
+apiVersion: operator.gardener.cloud/v1alpha1
+kind: Extension
+metadata:
+  name: extension-shoot-falco-service
+  annotations:
+    security.gardener.cloud/pod-security-enforce: baseline
+spec:
+  deployment:
+    extension:
+      injectGardenKubeconfig: true

--- a/example/extension/kustomization.yaml
+++ b/example/extension/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ./base
+
+patches:
+- path: extension.yaml

--- a/hack/api-reference/service.md
+++ b/hack/api-reference/service.md
@@ -106,8 +106,8 @@ Rules
 <td>
 <code>destinations</code></br>
 <em>
-<a href="#falco.extensions.gardener.cloud/v1alpha1.[]..Destination">
-[]..Destination
+<a href="#falco.extensions.gardener.cloud/v1alpha1.[]github.com/gardener/gardener-extension-shoot-falco-service/pkg/apis/service/v1alpha1.Destination">
+[]github.com/gardener/gardener-extension-shoot-falco-service/pkg/apis/service/v1alpha1.Destination
 </a>
 </em>
 </td>
@@ -496,8 +496,8 @@ Webhook
 <td>
 <code>custom</code></br>
 <em>
-<a href="#falco.extensions.gardener.cloud/v1alpha1.[]..CustomRule">
-[]..CustomRule
+<a href="#falco.extensions.gardener.cloud/v1alpha1.[]github.com/gardener/gardener-extension-shoot-falco-service/pkg/apis/service/v1alpha1.CustomRule">
+[]github.com/gardener/gardener-extension-shoot-falco-service/pkg/apis/service/v1alpha1.CustomRule
 </a>
 </em>
 </td>

--- a/hack/api-reference/service.md
+++ b/hack/api-reference/service.md
@@ -106,8 +106,8 @@ Rules
 <td>
 <code>destinations</code></br>
 <em>
-<a href="#falco.extensions.gardener.cloud/v1alpha1.[]github.com/gardener/gardener-extension-shoot-falco-service/pkg/apis/service/v1alpha1.Destination">
-[]github.com/gardener/gardener-extension-shoot-falco-service/pkg/apis/service/v1alpha1.Destination
+<a href="#falco.extensions.gardener.cloud/v1alpha1.[]..Destination">
+[]..Destination
 </a>
 </em>
 </td>
@@ -496,8 +496,8 @@ Webhook
 <td>
 <code>custom</code></br>
 <em>
-<a href="#falco.extensions.gardener.cloud/v1alpha1.[]github.com/gardener/gardener-extension-shoot-falco-service/pkg/apis/service/v1alpha1.CustomRule">
-[]github.com/gardener/gardener-extension-shoot-falco-service/pkg/apis/service/v1alpha1.CustomRule
+<a href="#falco.extensions.gardener.cloud/v1alpha1.[]..CustomRule">
+[]..CustomRule
 </a>
 </em>
 </td>


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR adds the generation for an `Extension` example manifest.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
An example `Extension` manifest for extension registration has been added. It can be found at [`example/extension.yaml`](https://github.com/gardener/gardener-extension-shoot-falco-service/blob/master/example/extension.yaml)
```
