### PR TITLE
Allow local development scenarios

### DIFF
--- a/charts/gardener-extension-shoot-falco-service/templates/deployment.yaml
+++ b/charts/gardener-extension-shoot-falco-service/templates/deployment.yaml
@@ -41,6 +41,7 @@ spec:
         networking.gardener.cloud/to-runtime-apiserver: allowed
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-public-networks: allowed
+        networking.resources.gardener.cloud/to-virtual-garden-istio-ingress-istio-ingressgateway-inte-02e09: allowed
     spec:
       {{- if gt (int .Values.replicaCount) 1 }}
       affinity:


### PR DESCRIPTION
**What this PR does / why we need it**:

In a local development scenario the gardener apiserver is deployed in the same Kubernetes cluster. This requires an additional network policy.

We assume that this setting is also necessary for deploying Falco into the Garden runtime cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
