### PR TITLE
Falcosidekick HA configuration

### DIFF
--- a/charts/internal/falco/values.yaml
+++ b/charts/internal/falco/values.yaml
@@ -1513,14 +1513,14 @@ falcosidekick:
   fullfqdn: false
   # -- Listen port. Default value: 2801
   listenPort: ""
-  # -- number of running pods
+  # -- Number of running pods
   replicaCount: 2
 
   # Deploy networkplicy for communication between Falco and Falcosidekick
   # this required when deploying Falco in shoot clusters
   deployNetworkPolicies: true
 
-  # -- number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
+  # -- Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
   # revisionHistoryLimit: 1
 
   image:
@@ -1707,7 +1707,23 @@ falcosidekick:
   tolerations: []
 
   # -- Affinity for the Sidekick pods
-  affinity: {}
+  affinity:
+    podAntiAffinity:
+      # Zones first
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: falcosidekick
+          topologyKey: topology.kubernetes.io/zone
+      # Nodes second
+      - weight: 50
+        podAffinityTerm:
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: falcosidekick
+          topologyKey: kubernetes.io/hostname
 
   # -- Extra volumes for sidekick deployment
   extraVolumes: []


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds anti-affinites for nodes and zones so that Falcosidekick is more resilient in case of (zone, node) outages 

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener-extension-shoot-falco-service/issues/297

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Falcosidekick deploys with anti-affinites for nodes and zones for HA setup

```
