### PR TITLE
Add Falco version to output fields

### DIFF
--- a/charts/internal/falco/templates/falco-pod-template.tpl
+++ b/charts/internal/falco/templates/falco-pod-template.tpl
@@ -118,6 +118,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+      {{- if .Values.falcoVersion }}
+        - name: FALCO_VERSION
+          value: {{ .Values.falcoVersion | quote }}
+      {{- end }}
       {{- if and .Values.driver.enabled (eq .Values.driver.kind "ebpf") }}
         - name: FALCO_BPF_PROBE
           value: {{ .Values.driver.ebpf.path }}

--- a/charts/internal/falco/values.yaml
+++ b/charts/internal/falco/values.yaml
@@ -818,6 +818,8 @@ falco:
   # in the form "foo_bar=$foo.bar"
   append_output:
     - suggested_output: true
+    - extra_fields:
+        - falco_version: "${FALCO_VERSION}"
 
   ##########################
   # Falco outputs channels #


### PR DESCRIPTION
**What this PR does / why we need it**:

Add Falco version to event fields

**Which issue(s) this PR fixes**:
Addresses https://github.com/gardener/gardener-extension-shoot-falco-service/issues/380

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Falco version added to event output_fields
```
