### PR TITLE
Admission: Prevent leaking the validatingwebhookconfiguration resource in virtual garden cluster

### DIFF
--- a/charts/gardener-extension-admission-shoot-falco-service/charts/application/templates/rbac.yaml
+++ b/charts/gardener-extension-admission-shoot-falco-service/charts/application/templates/rbac.yaml
@@ -33,8 +33,17 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  resourceNames:
+  - {{ include "name" . }}
+  verbs:
   - patch
   - update
+  - delete
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/gardener-extension-admission-shoot-falco-service/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener-extension-admission-shoot-falco-service/charts/runtime/templates/deployment.yaml
@@ -44,6 +44,9 @@ spec:
         - --webhook-config-mode=service
         {{- end}}
         - --webhook-config-namespace={{ .Release.Namespace }}
+        {{- if .Values.gardener.virtualCluster.namespace }}
+        - --webhook-config-owner-namespace={{ .Values.gardener.virtualCluster.namespace }}
+        {{- end }}
         {{- if .Values.restrictedUsage }}
         - --restricted-usage
         {{- end }}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area quality
/kind bug

**What this PR does / why we need it**:
This is required in order to prevent leaking of validatingwebhookconfigurations in virtual cluster.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/14334

**Special notes for your reviewer**:
Similar to https://github.com/gardener/gardener-extension-registry-cache/pull/550

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The gardener-extension-shoot-falco-service-admission's validatingwebhookconfiguration is no longer leaking in the virtual cluster when the shoot-falco-service operator.gardener.cloud/v1alpha1.Extension resource is deleted.
```
