### PR TITLE
Do not skip deletion of resources for hibernated shoots

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -277,9 +277,6 @@ func (a *actuator) Delete(ctx context.Context, log logr.Logger, ex *extensionsv1
 		if err != nil {
 			return fmt.Errorf("failed to get cluster config for shoot for Falco exension delete operation: %w", err)
 		}
-		if controller.IsHibernated(cluster) {
-			return nil
-		}
 		log.Info("Deleting falco resources for shoot " + cluster.Shoot.Name)
 	}
 	err = a.deleteShootResources(ctx, log, namespace, ex)


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/kind bug

**What this PR does / why we need it**:
This PR makes it so that the `ManagedResource`s deployed by the falco extension for `Shoot`s are always deleted so that deletion of hibernated `Shoot`s does not get blocked. Otherwise the following step in the deletion flow will fail: https://github.com/gardener/gardener/blob/9751585fd0f901b033204297dd6e7dafe1c691d8/pkg/gardenlet/controller/shoot/shoot/reconciler_delete.go#L558-L562

This is also the handling that is used by other extensions. During deletion of hibernated `Shoot`s, the GRM and kube-apiserver are scaled up, so it should not be a problem to delete the managed resources installed by the falco extension.

It is also not a problem when the extension is disabled for a hibernated shoot. Waiting for the shoot `ManagedResource`s to get deleted will fail, however that will not block `Shoot` reconciliation, as gardenlet skips waiting for stale extensions to be removed when the `Shoot` is hibernated: https://github.com/gardener/gardener/blob/9751585fd0f901b033204297dd6e7dafe1c691d8/pkg/gardenlet/controller/shoot/shoot/reconciler_reconcile.go#L1023-L1028

The deletion will eventually succeed when the `Shoot` is deleted or woken up.

These are the steps that I used to reproduce the issue:
1. Create a `Shoot` cluster
2. Enable the falco extension
3. Hibernate the `Shoot` cluster
4. Attempt to delete the cluster
 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
For the case where the extension is disabled for a hibernated shoot, an alternative handling would be to delete the `ManagedResource`s, but skip the waiting their deletion to finish. However, that would cause the `extension` resource to be removed without it having ensured that its `ManagedResource`s have been completely deleted.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
5. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
`ManagedResource`s deployed by the falco extension are now also deleted for hibernated `Shoot` clusters when the falco `Extension` resource is deleted.
```
