### PR TITLE
Add option for falcosidekick to create opensearch indexes

### DIFF
--- a/pkg/values/falcovalues.go
+++ b/pkg/values/falcovalues.go
@@ -266,6 +266,14 @@ func (c *ConfigBuilder) BuildFalcoValues(ctx context.Context, log logr.Logger, r
 				}
 				opensearch["flattenfields"] = flatten
 			}
+			// Optional: create index template
+			if createIndexTemplate, ok := secret.Data["createindextemplate"]; ok {
+				create, err := strconv.ParseBool(string(createIndexTemplate))
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse createindextemplate value: %w", err)
+				}
+				opensearch["createindextemplate"] = create
+			}
 			// Falcosidekick uses 'elasticsearch' config key
 			outputConfig := falcoOutputConfig{
 				key:   "elasticsearch",


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area security
/kind enhancement

**What this PR does / why we need it**:

This PR adds the `createindextemplate` flag to he elasticsearch/opensearch configuration. In some opensearch installations, indexes are not automatically created which means that for example `suffic: daily` would fail. Setting 
to `createindextemplate` to `true` fixes this issue.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add the `createindextemplate` flag to the open/elastic search destination.
```
