### PR TITLE
Drop support for K8s `<= 1.31`

### DIFF
--- a/charts/gardener-extension-admission-shoot-falco-service/charts/runtime/templates/service.yaml
+++ b/charts/gardener-extension-admission-shoot-falco-service/charts/runtime/templates/service.yaml
@@ -5,14 +5,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     networking.resources.gardener.cloud/from-all-webhook-targets-allowed-ports: '[{"protocol":"TCP","port":{{ .Values.webhookConfig.serverPort }}}]'
-    {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare "< 1.31-0" .Capabilities.KubeVersion.Version) }}
-    service.kubernetes.io/topology-mode: "auto"
-    {{- end }}
   labels:
 {{ include "labels" . | indent 4 }}
-    {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare "< 1.32-0" .Capabilities.KubeVersion.Version) }}
-    endpoint-slice-hints.resources.gardener.cloud/consider: "true"
-    {{- end }}
 spec:
   type: ClusterIP
   selector:
@@ -21,7 +15,7 @@ spec:
   - port: 443
     protocol: TCP
     targetPort: {{ .Values.webhookConfig.serverPort }}
-  {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare ">= 1.31-0" .Capabilities.KubeVersion.Version) (semverCompare "< 1.34-0" .Capabilities.KubeVersion.Version) }}
+  {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare "< 1.34-0" .Capabilities.KubeVersion.Version) }}
   trafficDistribution: PreferClose
   {{- end }}
   {{- if and .Values.service.topologyAwareRouting.enabled (semverCompare ">= 1.34-0" .Capabilities.KubeVersion.Version) }}

--- a/pkg/values/falcovalues_test.go
+++ b/pkg/values/falcovalues_test.go
@@ -748,7 +748,7 @@ var _ = Describe("Test value generation for helm chart without central storage",
 		Expect(scr[0]["name"]).To(Equal("my-shoot-configmap"))
 
 		// render chart and check if the values are set correctly
-		renderer, err := util.NewChartRendererForShoot("1.30.2")
+		renderer, err := util.NewChartRendererForShoot("1.32.2")
 		Expect(err).To(BeNil())
 		release, err := renderer.RenderEmbeddedFS(charts.InternalChart, filepath.Join(charts.InternalChartsPath, constants.FalcoChartname), constants.FalcoChartname, metav1.NamespaceSystem, values)
 		Expect(err).To(BeNil())
@@ -934,7 +934,7 @@ var _ = Describe("Test value generation for helm chart without central storage",
 		Expect(tolerations[1].Effect).To(Equal(corev1.TaintEffectNoSchedule))
 
 		// render chart and check if the values are set correctly
-		renderer, err := util.NewChartRendererForShoot("1.30.2")
+		renderer, err := util.NewChartRendererForShoot("1.32.2")
 		Expect(err).To(BeNil())
 		release, err := renderer.RenderEmbeddedFS(charts.InternalChart, filepath.Join(charts.InternalChartsPath, constants.FalcoChartname), constants.FalcoChartname, metav1.NamespaceSystem, values)
 		Expect(err).To(BeNil())
@@ -1566,7 +1566,7 @@ var _ = Describe("BuildFalcoValues", func() {
 		Expect(values).NotTo(BeNil())
 
 		// Render chart and check if the values are set correctly
-		renderer, err := util.NewChartRendererForShoot("1.30.2")
+		renderer, err := util.NewChartRendererForShoot("1.32.2")
 		Expect(err).To(BeNil())
 		release, err := renderer.RenderEmbeddedFS(charts.InternalChart, filepath.Join(charts.InternalChartsPath, constants.FalcoChartname), constants.FalcoChartname, metav1.NamespaceSystem, values)
 		Expect(err).To(BeNil())
@@ -1645,7 +1645,7 @@ var _ = Describe("BuildFalcoValues", func() {
 			Expect(requests["memory"]).To(Equal("128Mi"))
 
 			// Render chart and verify resources are set in DaemonSet
-			renderer, err := util.NewChartRendererForShoot("1.30.2")
+			renderer, err := util.NewChartRendererForShoot("1.32.2")
 			Expect(err).To(BeNil())
 			release, err := renderer.RenderEmbeddedFS(charts.InternalChart, filepath.Join(charts.InternalChartsPath, constants.FalcoChartname), constants.FalcoChartname, metav1.NamespaceSystem, values)
 			Expect(err).To(BeNil())


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area open-source
/kind cleanup

**What this PR does / why we need it**:
This PR removes the support for Kubernetes versions <= 1.31.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/13919

**Special notes for your reviewer**:


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
⚠️ This extension no longer supports Kubernetes versions `<= 1.31`. Please make sure to upgrade all Garden, Seed and Shoot clusters to at least version 1.32 before deploying this extension version.
```
