### PR TITLE
Adapt falco DaemonSet to revisionHistoryLimit=2

### DIFF
--- a/charts/internal/falco/templates/falco-daemonset.yaml
+++ b/charts/internal/falco/templates/falco-daemonset.yaml
@@ -11,6 +11,7 @@ metadata:
   {{ toYaml .Values.controller.annotations | nindent 4 }}
   {{- end }}
 spec:
+  revisionHistoryLimit: 2
   selector:
     matchLabels:
       {{- include "falco.selectorLabels" . | nindent 6 }}

--- a/charts/internal/falco/values.yaml
+++ b/charts/internal/falco/values.yaml
@@ -1540,7 +1540,7 @@ falcosidekick:
   deployNetworkPolicies: true
 
   # -- Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
-  # revisionHistoryLimit: 1
+  revisionHistoryLimit: 2
 
   image:
     # -- The image registry to pull from


### PR DESCRIPTION
**How to categorize this PR?**

/area security
/kind enhancement

**What this PR does / why we need it**:
The component checklist rule on `revisionHistoryLimit=2` was extended to cover DaemonSets in addition to Deployments (see gardener/gardener#13204). The internal falco chart's DaemonSet did not set `revisionHistoryLimit`, so it defaulted to 10. This change sets it to 2.

**Which issue(s) this PR fixes**:
Part of gardener/gardener#13889

**Special notes for your reviewer**:
N/A

**Release note**:
```other operator
Falco DaemonSet now sets `revisionHistoryLimit` to 2 to comply with the gardener component checklist.
```