### PR TITLE
Add `splunk` destination for falco events

### DIFF
--- a/docs/falco-configuration.md
+++ b/docs/falco-configuration.md
@@ -81,7 +81,7 @@ Below is the full configuration, explained in detail:
         custom:
         - resourceName: rules1
       destinations:
-        # Possible values: stdout, logging, webhook
+        # Possible values: stdout, logging, custom, opensearch, splunk
         - name: custom
           # Options, may be required to configure destination
           resourceSecretName: secret
@@ -184,6 +184,7 @@ Falco can post events to several internal and external storage providers:
 - `central`: Post events to a central storage, if offered by the infrastructure provider
 - `logging`: Post events to the local cluster logging stack
 - `opensearch`: Post events to an OpenSearch cluster for centralized analysis
+- `splunk`: Post events to a Splunk instance via the HTTP Event Collector (HEC)
 - `custom`: Post events to a custom web server
 
 More details for each destination are described below.
@@ -448,6 +449,66 @@ Falco events are forwarded to central storage via the Falcosidekick [webhook out
 The [Falco event ingestor](https://github.com/gardener/falco-event-ingestor) provides a REST API to receive Falco events, validates event integrity, stores events in an SQL database, and implements configurable rate limiting per cluster to prevent overload.
 
 The [Falco event provider](https://github.com/gardener/falco-event-provider) offers a REST API to access the database. Cluster users must present a valid token (with Viewer access for the Gardener project namespace) to retrieve Falco events for their cluster.
+
+## Splunk Destination (`splunk` Option)
+
+This option forwards Falco events to a Splunk instance via the [HTTP Event Collector (HEC)](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector). It uses the Falcosidekick [Splunk output](https://github.com/falcosecurity/falcosidekick/blob/master/docs/outputs/splunk.md).
+
+### Configuration
+
+The `splunk` destination requires additional configuration:
+
+```yaml
+      destinations:
+      - name: splunk
+        resourceSecretName: splunk-config
+```
+
+The `resourceSecretName` references a secret defined in the `resources` section of the shoot manifest:
+
+```yaml
+  resources:
+  - name: splunk-config
+    resourceRef:
+      apiVersion: v1
+      kind: Secret
+      name: my-splunk-config
+```
+
+The secret contains the following values:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-splunk-config
+  namespace: <project namespace in garden cluster>
+stringData:
+  # Required: Splunk HEC endpoint URL
+  host: "https://splunk-hec.example.com/services/collector/event"
+
+  # Required: Splunk HEC token
+  token: "your-hec-token"
+
+  # Optional: Verify SSL certificates (default: true)
+  checkcert: "true"
+
+  # Optional: Minimum priority level
+  # Options: "emergency", "alert", "critical", "error", "warning", "notice", "informational", "debug"
+  minimumpriority: "notice"
+
+  # Optional: Custom HTTP headers (YAML map format)
+  customheaders: |
+    X-Custom-Header: value
+```
+
+### Prerequisites
+
+Before configuring the Splunk destination, ensure that:
+
+1. The Splunk HEC is enabled on your Splunk instance
+2. A HEC token has been created with appropriate permissions
+3. The HEC endpoint is reachable from the shoot cluster (the `host` field must include the full URL path)
 
 ## Known Issues
 

--- a/pkg/admission/validator/shoot_validator.go
+++ b/pkg/admission/validator/shoot_validator.go
@@ -29,7 +29,7 @@ import (
 
 const (
 	// maxEventDestinations defines the maximum number of event destinations allowed
-	maxEventDestinations = 2
+	maxEventDestinations = 3
 )
 
 // extra Falco options
@@ -354,7 +354,19 @@ func verifyEventDestinationsCommon(falcoConf *service.FalcoServiceConfig, resour
 	})
 
 	if idxCustom != -1 {
-		return verifyCustomDestination(falcoConf.Destinations[idxCustom], resources)
+		if err := verifyCustomDestination(falcoConf.Destinations[idxCustom], resources); err != nil {
+			return err
+		}
+	}
+
+	idxSplunk := slices.IndexFunc(falcoConf.Destinations, func(dest service.Destination) bool {
+		return dest.Name == constants.FalcoEventDestinationSplunk
+	})
+
+	if idxSplunk != -1 {
+		if err := verifySplunkDestination(falcoConf.Destinations[idxSplunk], resources); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -375,6 +387,25 @@ func verifyCustomDestination(customDest service.Destination, resources []core.Na
 
 	if !found {
 		return fmt.Errorf("custom event destination config %s not found in resources", *customDest.ResourceSecretName)
+	}
+	return nil
+}
+
+func verifySplunkDestination(splunkDest service.Destination, resources []core.NamedResourceReference) error {
+	if splunkDest.ResourceSecretName == nil {
+		return fmt.Errorf("splunk event destination is set but no secret config is defined")
+	}
+
+	found := false
+	for _, s := range resources {
+		if s.ResourceRef.Kind == "Secret" && s.Name == *splunkDest.ResourceSecretName {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("splunk event destination config %s not found in resources", *splunkDest.ResourceSecretName)
 	}
 	return nil
 }

--- a/pkg/admission/validator/shoot_validator_test.go
+++ b/pkg/admission/validator/shoot_validator_test.go
@@ -487,6 +487,41 @@ var (
 		 }
 		]
 	}`
+
+	falcoExtensionSplunk = `
+	{
+		"apiVersion": "falco.extensions.gardener.cloud/v1alpha1",
+		"kind": "FalcoServiceConfig",
+		"falcoVersion": "1.2.3",
+		"rules": {
+			"standard": [
+				"falco-rules"
+			]
+		},
+		"destinations": [
+		 {
+			"name": "splunk",
+			"resourceSecretName": "my-custom-webhook-ref"
+		 }
+		]
+	}`
+
+	falcoExtensionSplunkNoSecret = `
+	{
+		"apiVersion": "falco.extensions.gardener.cloud/v1alpha1",
+		"kind": "FalcoServiceConfig",
+		"falcoVersion": "1.2.3",
+		"rules": {
+			"standard": [
+				"falco-rules"
+			]
+		},
+		"destinations": [
+		 {
+			"name": "splunk"
+		 }
+		]
+	}`
 )
 
 func init() {
@@ -687,7 +722,24 @@ var _ = Describe("Test validator", Label("falcovalues"), func() {
 			},
 		}
 		err = verifyEventDestinations(falcoConf, genericShootWithSecret)
-		Expect(err).NotTo(BeNil(), "Three destinations were accepted")
+		Expect(err).To(BeNil(), "Three destinations were not accepted")
+
+		falcoConf.Destinations = []service.Destination{
+			{
+				Name: constants.FalcoEventDestinationCentral,
+			},
+			{
+				Name: constants.FalcoEventDestinationStdout,
+			},
+			{
+				Name: constants.FalcoEventDestinationLogging,
+			},
+			{
+				Name: constants.FalcoEventDestinationOTLP,
+			},
+		}
+		err = verifyEventDestinations(falcoConf, genericShootWithSecret)
+		Expect(err).NotTo(BeNil(), "Four destinations were accepted")
 
 		falcoConf.Destinations = []service.Destination{
 			{Name: constants.FalcoEventDestinationLogging},
@@ -725,6 +777,48 @@ var _ = Describe("Test validator", Label("falcovalues"), func() {
 		}
 		err = verifyEventDestinations(falcoConf, genericShootWithSecret)
 		Expect(err).To(BeNil(), "Correct custom destinations was not accepted")
+
+		// Splunk destination tests
+		falcoConf.Destinations = []service.Destination{
+			{
+				Name: constants.FalcoEventDestinationSplunk,
+			},
+		}
+		err = verifyEventDestinations(falcoConf, genericShootWithSecret)
+		Expect(err).NotTo(BeNil(), "Splunk destination without secret ref was accepted")
+
+		falcoConf.Destinations = []service.Destination{
+			{
+				Name:               constants.FalcoEventDestinationSplunk,
+				ResourceSecretName: stringValue("non-existing-splunk-secret"),
+			},
+		}
+		err = verifyEventDestinations(falcoConf, genericShootWithSecret)
+		Expect(err).NotTo(BeNil(), "Splunk destination with non-existent secret was accepted")
+
+		falcoConf.Destinations = []service.Destination{
+			{
+				Name:               constants.FalcoEventDestinationSplunk,
+				ResourceSecretName: stringValue("my-custom-webhook-ref"),
+			},
+		}
+		err = verifyEventDestinations(falcoConf, genericShootWithSecret)
+		Expect(err).To(BeNil(), "Splunk destination with valid secret was not accepted")
+
+		falcoConf.Destinations = []service.Destination{
+			{
+				Name:               constants.FalcoEventDestinationSplunk,
+				ResourceSecretName: stringValue("my-custom-webhook-ref"),
+			},
+			{
+				Name: constants.FalcoEventDestinationStdout,
+			},
+			{
+				Name: constants.FalcoEventDestinationLogging,
+			},
+		}
+		err = verifyEventDestinations(falcoConf, genericShootWithSecret)
+		Expect(err).To(BeNil(), "Splunk with two other destinations was not accepted")
 	})
 
 	It("can verify rules", func(ctx SpecContext) {
@@ -872,6 +966,9 @@ var _ = Describe("Test validator", Label("falcovalues"), func() {
 
 		err = f(falcoExtensionwithShootRules2)
 		Expect(err).To(BeNil(), "Legal extension is not detected as such")
+
+		err = f(falcoExtensionSplunk)
+		Expect(err).To(BeNil(), "Legal splunk extension is not detected as such")
 	})
 
 	It("verify illegal extensions", func(ctx SpecContext) {
@@ -927,6 +1024,10 @@ var _ = Describe("Test validator", Label("falcovalues"), func() {
 		err = f(falcoExtensionIllegalWrongCustomRule2)
 		Expect(err).To(Not(BeNil()), "Illegal extension is not detected as such")
 		Expect(err.Error()).To(ContainSubstring("found custom rule with both resource name and shoot config map defined"), "Illegal extension is not detected as such ")
+
+		err = f(falcoExtensionSplunkNoSecret)
+		Expect(err).To(Not(BeNil()), "Splunk without secret ref is not detected as illegal")
+		Expect(err.Error()).To(ContainSubstring("splunk event destination is set but no secret config is defined"), "Splunk without secret ref error message mismatch")
 	})
 
 	It("checks if central logging is enabled", func(ctx SpecContext) {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -48,6 +48,7 @@ const (
 	FalcoEventDestinationCustom     = "custom"
 	FalcoEventDestinationOTLP       = "otlp"
 	FalcoEventDestinationOpenSearch = "opensearch"
+	FalcoEventDestinationSplunk     = "splunk"
 
 	DefaultCALifetime   = time.Hour * 24 * 365 * 2
 	DefaultCARenewAfter = DefaultCALifetime - 60
@@ -78,8 +79,8 @@ const (
 var (
 	AlwaysEnabledNamespaces         = []string{"garden"}
 	CentralLoggingAllowedNamespaces = []string{"garden"}
-	AllowedDestinations             = []string{FalcoEventDestinationCentral, FalcoEventDestinationLogging, FalcoEventDestinationStdout, FalcoEventDestinationCustom, FalcoEventDestinationOTLP, FalcoEventDestinationOpenSearch}
-	AllowedDestinationsSeed         = []string{FalcoEventDestinationCentral, FalcoEventDestinationStdout, FalcoEventDestinationCustom, FalcoEventDestinationOpenSearch}
+	AllowedDestinations             = []string{FalcoEventDestinationCentral, FalcoEventDestinationLogging, FalcoEventDestinationStdout, FalcoEventDestinationCustom, FalcoEventDestinationOTLP, FalcoEventDestinationOpenSearch, FalcoEventDestinationSplunk}
+	AllowedDestinationsSeed         = []string{FalcoEventDestinationCentral, FalcoEventDestinationStdout, FalcoEventDestinationCustom, FalcoEventDestinationOpenSearch, FalcoEventDestinationSplunk}
 
 	// Default Event logger if not specified in controller configuration
 	// (apis.Falco.DefaultEventDestination)

--- a/pkg/values/falcovalues.go
+++ b/pkg/values/falcovalues.go
@@ -273,6 +273,48 @@ func (c *ConfigBuilder) BuildFalcoValues(ctx context.Context, log logr.Logger, r
 			}
 			falcoOutputConfigs = append(falcoOutputConfigs, outputConfig)
 
+		case constants.FalcoEventDestinationSplunk:
+			splunk := map[string]any{}
+			secret, err := c.loadCustomWebhookSecret(ctx, log, reconcileCtx, *dest.ResourceSecretName)
+			if err != nil {
+				return nil, err
+			}
+
+			if host, ok := secret.Data["host"]; ok {
+				splunk["host"] = string(host)
+			} else {
+				return nil, fmt.Errorf("splunk host is missing")
+			}
+			if token, ok := secret.Data["token"]; ok {
+				splunk["token"] = string(token)
+			} else {
+				return nil, fmt.Errorf("splunk token is missing")
+			}
+			if checkcert, ok := secret.Data["checkcert"]; ok {
+				checkcertBool, err := strconv.ParseBool(string(checkcert))
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse checkcert value: %w", err)
+				}
+				splunk["checkcert"] = checkcertBool
+			} else {
+				splunk["checkcert"] = true
+			}
+			if minimumpriority, ok := secret.Data["minimumpriority"]; ok {
+				splunk["minimumpriority"] = string(minimumpriority)
+			}
+			if customHeaders, ok := secret.Data["customheaders"]; ok {
+				customHeadersMap := map[string]string{}
+				if err := yaml.Unmarshal(customHeaders, &customHeadersMap); err != nil {
+					return nil, fmt.Errorf("failed to parse custom headers: %w", err)
+				}
+				splunk["customheaders"] = customHeadersMap
+			}
+			outputConfig := falcoOutputConfig{
+				key:   "splunk",
+				value: splunk,
+			}
+			falcoOutputConfigs = append(falcoOutputConfigs, outputConfig)
+
 		case constants.FalcoEventDestinationCentral:
 
 			if c.config.Falco.CentralStorage == nil {

--- a/pkg/values/falcovalues_test.go
+++ b/pkg/values/falcovalues_test.go
@@ -267,6 +267,14 @@ var (
 							APIVersion: "v1",
 						},
 					},
+					{
+						Name: "splunk-config",
+						ResourceRef: autoscalingv1.CrossVersionObjectReference{
+							Kind:       "Secret",
+							Name:       "splunk-config-secret",
+							APIVersion: "v1",
+						},
+					},
 				},
 			},
 			Status: gardencorev1beta1.ShootStatus{
@@ -405,6 +413,19 @@ var (
 		},
 	}
 
+	falcoServiceConfigSplunk = &service.FalcoServiceConfig{
+		FalcoVersion: stringValue("0.38.0"),
+		Rules: &service.Rules{
+			StandardRules: []string{"falco-rules"},
+		},
+		Destinations: []service.Destination{
+			{
+				Name:               "splunk",
+				ResourceSecretName: stringValue("splunk-config"),
+			},
+		},
+	}
+
 	webhookSecrets = &corev1.SecretList{
 		Items: []corev1.Secret{
 			{
@@ -437,6 +458,18 @@ Authorization: Bearer my-token`),
 					"flattenfields":    []byte("false"),
 					"customheaders": []byte(`
 X-Custom-Header: test-value`),
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "shoot--test--foo",
+					Name:      "ref-splunk-config-secret",
+				},
+				Data: map[string][]byte{
+					"host":            []byte("https://splunk-hec.example.com:8088"),
+					"token":           []byte("my-hec-token"),
+					"checkcert":       []byte("true"),
+					"minimumpriority": []byte("warning"),
 				},
 			},
 		},
@@ -855,6 +888,29 @@ var _ = Describe("Test value generation for helm chart without central storage",
 		Expect(opensearch["flattenfields"].(bool)).To(BeFalse())
 		Expect(opensearch).To(HaveKey("customheaders"))
 		Expect(opensearch["customheaders"].(map[string]string)["X-Custom-Header"]).To(Equal("test-value"))
+	})
+
+	It("Test Splunk functionality with secret", func(ctx SpecContext) {
+		shootReconcileCtx.FalcoServiceConfig = falcoServiceConfigSplunk
+		values, err := configBuilder.BuildFalcoValues(context.TODO(), logger, shootReconcileCtx)
+		Expect(err).To(BeNil())
+
+		js, err := json.MarshalIndent((values), "", "    ")
+		Expect(err).To(BeNil())
+		Expect(len(js)).To(BeNumerically(">", 100))
+
+		config := values["falcosidekick"].(map[string]interface{})["config"].(map[string]interface{})
+		Expect(config).To(HaveKey("splunk"))
+
+		splunk := config["splunk"].(map[string]interface{})
+		Expect(splunk).To(HaveKey("host"))
+		Expect(splunk["host"].(string)).To(Equal("https://splunk-hec.example.com:8088"))
+		Expect(splunk).To(HaveKey("token"))
+		Expect(splunk["token"].(string)).To(Equal("my-hec-token"))
+		Expect(splunk).To(HaveKey("checkcert"))
+		Expect(splunk["checkcert"].(bool)).To(BeTrue())
+		Expect(splunk).To(HaveKey("minimumpriority"))
+		Expect(splunk["minimumpriority"].(string)).To(Equal("warning"))
 	})
 
 	It("Test cluster logging functionality", func(ctx SpecContext) {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR adds the `splunk` destination for `falco` events via `falcosidekick`. It can be configured via the following spec:

```yaml
  resources:
  - name: splunk-config
    resourceRef:
      apiVersion: v1
      kind: Secret
      name: my-splunk-config
```

The secret contains the following values:

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: my-splunk-config
  namespace: <project namespace in garden cluster>
stringData:
  # Required: Splunk HEC endpoint URL
  host: "https://splunk-hec.example.com/services/collector/event"
  # Required: Splunk HEC token
  token: "your-hec-token"
  # Optional: Verify SSL certificates (default: true)
  checkcert: "true"
  # Optional: Minimum priority level
  # Options: "emergency", "alert", "critical", "error", "warning", "notice", "informational", "debug"
  minimumpriority: "notice"
  # Optional: Custom HTTP headers (YAML map format)
  customheaders: |
    X-Custom-Header: value
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Added new `splunk` destination for falco events.
```
```noteworthy user
Increased the limit of configured destinations from `2` to `3`.
```
