### PR TITLE
fix sourceRepository for falcosidekick v2.35.0

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -28,7 +28,7 @@ images:
       integrity_requirement: 'low'
       availability_requirement: 'low'
 - name: falcosidekick
-  sourceRepository: github.com/falcosecurity/falcosidekick
+  sourceRepository: github.com/gardener/falcosidekick
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/falcosidekick-fork
   tag: v2.35.0
   version: 2.35.0


### PR DESCRIPTION
The `sourceRepository` for the falcosidekick v2.35.0 image vector entry was set to `github.com/falcosecurity/falcosidekick` (upstream), but the `repository` points to the Gardener fork OCI image at `europe-docker.pkg.dev/gardener-project/releases/gardener/falcosidekick-fork`. cc-utils derives the OCM component reference from `sourceRepository`, causing it to emit a cref to `github.com/falcosecurity/falcosidekick` which does not exist in any reachable OCM repository. The correct component name is `github.com/gardener/falcosidekick`. This broke upgrade-dependencies pipelines in consumers (e.g. landscape-setup), crashing during BOM diff generation when resolving the non-existent cref.