### PR TITLE
Add gateway wildcard certifcate secret name to values

### DIFF
--- a/cmd/gardener-extension-shoot-falco-service/app/app.go
+++ b/cmd/gardener-extension-shoot-falco-service/app/app.go
@@ -165,7 +165,12 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 				seedIngressDomain = seed.Spec.Ingress.Domain
 			}
 
-			if err := additional.AddToManager(mgr, log, restOpts.Completed().Config, completedMgrOpts.LeaderElectionNamespace, additionalConfig, seedIngressDomain); err != nil {
+			ingressWildcardCertName, err := getIngressWildcardCertificateName(ctx, mgr.GetClient())
+			if err != nil {
+				return fmt.Errorf("could not get ingress wildcard certificate name: %w", err)
+			}
+
+			if err := additional.AddToManager(mgr, log, restOpts.Completed().Config, completedMgrOpts.LeaderElectionNamespace, additionalConfig, seedIngressDomain, ingressWildcardCertName); err != nil {
 				return fmt.Errorf("could not add additional seed resources controller: %w", err)
 			}
 
@@ -188,4 +193,18 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 	aggOption.AddFlags(cmd.Flags())
 
 	return cmd
+}
+
+func getIngressWildcardCertificateName(ctx context.Context, c client.Client) (string, error) {
+	secretList := &corev1.SecretList{}
+	if err := c.List(ctx, secretList,
+		client.InNamespace("garden"),
+		client.MatchingLabels{"gardener.cloud/role": "controlplane-cert"},
+	); err != nil {
+		return "", fmt.Errorf("failed to list controlplane-cert secrets: %w", err)
+	}
+	if len(secretList.Items) == 0 {
+		return "", nil
+	}
+	return secretList.Items[0].Name, nil
 }

--- a/cmd/gardener-extension-shoot-falco-service/app/app.go
+++ b/cmd/gardener-extension-shoot-falco-service/app/app.go
@@ -14,8 +14,10 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller/heartbeat"
 	heartbeatcmd "github.com/gardener/gardener/extensions/pkg/controller/heartbeat/cmd"
 	"github.com/gardener/gardener/extensions/pkg/util"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/logger"
+	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/dynamic"
@@ -165,7 +167,7 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 				seedIngressDomain = seed.Spec.Ingress.Domain
 			}
 
-			ingressWildcardCertName, err := getIngressWildcardCertificateName(ctx, mgr.GetClient())
+			ingressWildcardCertName, err := getIngressWildcardCertificateName(ctx, mgr.GetClient(), log)
 			if err != nil {
 				return fmt.Errorf("could not get ingress wildcard certificate name: %w", err)
 			}
@@ -195,16 +197,20 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 	return cmd
 }
 
-func getIngressWildcardCertificateName(ctx context.Context, c client.Client) (string, error) {
+func getIngressWildcardCertificateName(ctx context.Context, c client.Client, log logr.Logger) (string, error) {
 	secretList := &corev1.SecretList{}
 	if err := c.List(ctx, secretList,
-		client.InNamespace("garden"),
-		client.MatchingLabels{"gardener.cloud/role": "controlplane-cert"},
+		client.InNamespace(v1beta1constants.GardenNamespace),
+		client.MatchingLabels{v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlaneWildcardCert},
 	); err != nil {
 		return "", fmt.Errorf("failed to list controlplane-cert secrets: %w", err)
 	}
 	if len(secretList.Items) == 0 {
+		log.Info("no controlplane-cert secret found in garden namespace")
 		return "", nil
+	}
+	if len(secretList.Items) > 1 {
+		log.Info("multiple controlplane-cert secrets found, using the first one")
 	}
 	return secretList.Items[0].Name, nil
 }

--- a/pkg/controller/additional/add.go
+++ b/pkg/controller/additional/add.go
@@ -20,8 +20,8 @@ import (
 const ControllerName = "additional-seed-resources"
 
 // AddToManager registers the additional seed resources reconciler with the manager.
-func AddToManager(mgr manager.Manager, log logr.Logger, restConfig *rest.Config, namespace string, additional *config.AdditionalConfig, seedIngressDomain string) error {
-	r, err := NewReconciler(mgr.GetClient(), restConfig, namespace, additional, seedIngressDomain, log.WithName(ControllerName))
+func AddToManager(mgr manager.Manager, log logr.Logger, restConfig *rest.Config, namespace string, additional *config.AdditionalConfig, seedIngressDomain string, ingressWildcardCertificateName string) error {
+	r, err := NewReconciler(mgr.GetClient(), restConfig, namespace, additional, seedIngressDomain, ingressWildcardCertificateName, log.WithName(ControllerName))
 	if err != nil {
 		return fmt.Errorf("could not create additional seed resources reconciler: %w", err)
 	}

--- a/pkg/controller/additional/reconciler.go
+++ b/pkg/controller/additional/reconciler.go
@@ -39,23 +39,25 @@ const reconcileInterval = 1 * time.Minute
 // Reconciler periodically deploys additional seed ManagedResources from OCI Helm charts
 // and cleans up stale ones that are no longer in the config.
 type Reconciler struct {
-	client            client.Client
-	namespace         string
-	additional        *config.AdditionalConfig
-	log               logr.Logger
-	helmRegistry      *oci.HelmRegistry
-	renderer          chartrenderer.Interface
-	seedIngressDomain string
+	client                      client.Client
+	namespace                   string
+	additional                  *config.AdditionalConfig
+	log                         logr.Logger
+	helmRegistry                *oci.HelmRegistry
+	renderer                    chartrenderer.Interface
+	seedIngressDomain           string
+	ingressWildcardCertificateName string
 }
 
 // NewReconciler creates a new Reconciler for additional seed resources.
-func NewReconciler(c client.Client, restConfig *rest.Config, namespace string, additional *config.AdditionalConfig, seedIngressDomain string, log logr.Logger) (*Reconciler, error) {
+func NewReconciler(c client.Client, restConfig *rest.Config, namespace string, additional *config.AdditionalConfig, seedIngressDomain string, ingressWildcardCertificateName string, log logr.Logger) (*Reconciler, error) {
 	r := &Reconciler{
-		client:            c,
-		namespace:         namespace,
-		additional:        additional,
-		seedIngressDomain: seedIngressDomain,
-		log:               log,
+		client:                         c,
+		namespace:                      namespace,
+		additional:                     additional,
+		seedIngressDomain:              seedIngressDomain,
+		ingressWildcardCertificateName: ingressWildcardCertificateName,
+		log:                            log,
 	}
 
 	if restConfig != nil {
@@ -145,6 +147,11 @@ func (r *Reconciler) deployResource(ctx context.Context, res config.AdditionalSe
 			return fmt.Errorf("failed to unmarshal helm values: %w", err)
 		}
 	}
+
+	if values == nil {
+		values = make(map[string]interface{})
+	}
+	values["ingressWildcardCertificateName"] = r.ingressWildcardCertificateName
 
 	release, err := r.renderer.RenderArchive(archive, res.Name, r.namespace, values)
 	if err != nil {

--- a/pkg/controller/additional/reconciler.go
+++ b/pkg/controller/additional/reconciler.go
@@ -39,13 +39,13 @@ const reconcileInterval = 1 * time.Minute
 // Reconciler periodically deploys additional seed ManagedResources from OCI Helm charts
 // and cleans up stale ones that are no longer in the config.
 type Reconciler struct {
-	client                      client.Client
-	namespace                   string
-	additional                  *config.AdditionalConfig
-	log                         logr.Logger
-	helmRegistry                *oci.HelmRegistry
-	renderer                    chartrenderer.Interface
-	seedIngressDomain           string
+	client                         client.Client
+	namespace                      string
+	additional                     *config.AdditionalConfig
+	log                            logr.Logger
+	helmRegistry                   *oci.HelmRegistry
+	renderer                       chartrenderer.Interface
+	seedIngressDomain              string
 	ingressWildcardCertificateName string
 }
 

--- a/pkg/controller/additional/reconciler_test.go
+++ b/pkg/controller/additional/reconciler_test.go
@@ -149,7 +149,8 @@ var _ = Describe("Reconciler", func() {
 		It("should pass ingressWildcardCertificateName in rendered chart values", func() {
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
-				w.Write([]byte(`{"major":"1","minor":"30","gitVersion":"v1.30.0"}`))
+				_, err := w.Write([]byte(`{"major":"1","minor":"30","gitVersion":"v1.30.0"}`))
+				Expect(err).NotTo(HaveOccurred())
 			}))
 			defer server.Close()
 

--- a/pkg/controller/additional/reconciler_test.go
+++ b/pkg/controller/additional/reconciler_test.go
@@ -5,9 +5,14 @@
 package additional_test
 
 import (
+	"archive/tar"
 	"bytes"
+	"compress/gzip"
 	"context"
+	"encoding/base64"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"time"
 
@@ -19,6 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -138,6 +144,48 @@ var _ = Describe("Reconciler", func() {
 			r, err := additional.NewReconciler(nil, nil, namespace, &config.AdditionalConfig{}, "", "", zap.New(zap.WriteTo(GinkgoWriter)))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(r.Deploy(ctx)).To(Succeed())
+		})
+
+		It("should pass ingressWildcardCertificateName in rendered chart values", func() {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(`{"major":"1","minor":"30","gitVersion":"v1.30.0"}`))
+			}))
+			defer server.Close()
+
+			restConfig := &rest.Config{Host: server.URL}
+			chartArchive := buildTestChart()
+			chartB64 := base64.StdEncoding.EncodeToString(chartArchive)
+
+			fakeClient := crfake.NewClientBuilder().WithScheme(scheme).Build()
+			r, err := additional.NewReconciler(fakeClient, restConfig, namespace, &config.AdditionalConfig{
+				SeedManagedResources: []config.AdditionalSeedManagedResource{
+					{
+						Name: "test-chart",
+						Helm: config.HelmConfig{
+							Chart: &chartB64,
+						},
+					},
+				},
+			}, "", "my-wildcard-cert", zap.New(zap.WriteTo(GinkgoWriter)))
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(r.Deploy(ctx)).To(Succeed())
+
+			secretList := &corev1.SecretList{}
+			Expect(fakeClient.List(ctx, secretList, client.InNamespace(namespace))).To(Succeed())
+			Expect(secretList.Items).NotTo(BeEmpty())
+
+			var found bool
+			for _, secret := range secretList.Items {
+				for _, v := range secret.Data {
+					if strings.Contains(string(v), "my-wildcard-cert") {
+						found = true
+						break
+					}
+				}
+			}
+			Expect(found).To(BeTrue(), "expected rendered manifests to contain ingressWildcardCertificateName value")
 		})
 	})
 })
@@ -378,3 +426,30 @@ type: Opaque
 		Expect(validDocs).To(Equal(2))
 	})
 })
+
+func buildTestChart() []byte {
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gw)
+
+	chartYaml := "apiVersion: v2\nname: test-chart\nversion: 0.1.0\n"
+	tmpl := "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: test-cm\ndata:\n  certName: {{ .Values.ingressWildcardCertificateName }}\n"
+
+	addFile(tw, "test-chart/Chart.yaml", chartYaml)
+	addFile(tw, "test-chart/templates/configmap.yaml", tmpl)
+
+	tw.Close()
+	gw.Close()
+	return buf.Bytes()
+}
+
+func addFile(tw *tar.Writer, name, content string) {
+	hdr := &tar.Header{
+		Name: name,
+		Mode: 0644,
+		Size: int64(len(content)),
+	}
+	ExpectWithOffset(1, tw.WriteHeader(hdr)).To(Succeed())
+	_, err := tw.Write([]byte(content))
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+}

--- a/pkg/controller/additional/reconciler_test.go
+++ b/pkg/controller/additional/reconciler_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Reconciler", func() {
 	Describe("Reconcile", func() {
 		It("should requeue after the reconcile interval on success", func() {
 			fakeClient := crfake.NewClientBuilder().WithScheme(scheme).Build()
-			r, err := additional.NewReconciler(fakeClient, nil, namespace, nil, "", zap.New(zap.WriteTo(GinkgoWriter)))
+			r, err := additional.NewReconciler(fakeClient, nil, namespace, nil, "", "", zap.New(zap.WriteTo(GinkgoWriter)))
 			Expect(err).NotTo(HaveOccurred())
 
 			result, reconcileErr := r.Reconcile(ctx, reconcile.Request{})
@@ -76,7 +76,7 @@ var _ = Describe("Reconciler", func() {
 		BeforeEach(func() {
 			fakeClient = crfake.NewClientBuilder().WithScheme(scheme).Build()
 			var err error
-			r, err = additional.NewReconciler(fakeClient, nil, namespace, nil, "", zap.New(zap.WriteTo(GinkgoWriter)))
+			r, err = additional.NewReconciler(fakeClient, nil, namespace, nil, "", "", zap.New(zap.WriteTo(GinkgoWriter)))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -89,7 +89,7 @@ var _ = Describe("Reconciler", func() {
 				SeedManagedResources: []config.AdditionalSeedManagedResource{
 					{Name: "old-nginx"},
 				},
-			}, "", zap.New(zap.WriteTo(GinkgoWriter)))
+			}, "", "", zap.New(zap.WriteTo(GinkgoWriter)))
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(r.Cleanup(ctx)).To(Succeed())
@@ -129,13 +129,13 @@ var _ = Describe("Reconciler", func() {
 
 	Describe("Deploy", func() {
 		It("should return nil when additional config is nil", func() {
-			r, err := additional.NewReconciler(nil, nil, namespace, nil, "", zap.New(zap.WriteTo(GinkgoWriter)))
+			r, err := additional.NewReconciler(nil, nil, namespace, nil, "", "", zap.New(zap.WriteTo(GinkgoWriter)))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(r.Deploy(ctx)).To(Succeed())
 		})
 
 		It("should return nil when seed managed resources list is empty", func() {
-			r, err := additional.NewReconciler(nil, nil, namespace, &config.AdditionalConfig{}, "", zap.New(zap.WriteTo(GinkgoWriter)))
+			r, err := additional.NewReconciler(nil, nil, namespace, &config.AdditionalConfig{}, "", "", zap.New(zap.WriteTo(GinkgoWriter)))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(r.Deploy(ctx)).To(Succeed())
 		})


### PR DESCRIPTION

<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area security
/kind enhancement

**What this PR does / why we need it**:

If the additional component wishes to expose an ingress or gateway it needs to know the ingress wildcard certificate name. It can ignore the value if it is not required.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add wildcard certificate name in values for additional deployment done alongside the extension.
```
