### PR TITLE
Add `falco-ops` image for executing bash scripts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,6 +39,18 @@ jobs:
           - name: gardener-extension-admission-shoot-falco-service
             target: gardener-extension-admission-shoot-falco-service
             oci-repository: gardener/extensions/admission-shoot-falco-service
+          - name: falco-ops
+            target: falco-ops
+            oci-repository: gardener/falco-ops
+            ocm-labels:
+              name: gardener.cloud/cve-categorisation
+              value:
+                network_exposure: private
+                authentication_enforced: false
+                user_interaction: end-user
+                confidentiality_requirement: none
+                integrity_requirement: high
+                availability_requirement: none
     with:
       name: ${{ matrix.args.name }}
       version: ${{ needs.prepare.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,3 +34,18 @@ FROM base AS gardener-extension-admission-shoot-falco-service
 WORKDIR /
 COPY --from=builder /go/bin/gardener-extension-admission-shoot-falco-service /gardener-extension-admission-shoot-falco-service
 ENTRYPOINT ["/gardener-extension-admission-shoot-falco-service"]
+
+############# falco-ops-builder
+FROM alpine:3.24.1 AS falco-ops-builder
+
+RUN mkdir -p /volume/bin /volume/lib /volume/tmp \
+    && cp /bin/busybox /volume/bin/                   && echo "package busybox" \
+    && cp -d /lib/ld-musl-* /volume/lib/              && echo "package musl" \
+    && for cmd in sh awk date echo grep head sed sleep wget; do \
+         ln -s busybox /volume/bin/$cmd; \
+       done
+
+############# falco-ops
+FROM scratch AS falco-ops
+WORKDIR /
+COPY --from=falco-ops-builder /volume .

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ GARDENER_HACK_DIR           := $(shell go list -m -f "{{.Dir}}" github.com/garde
 EXTENSION_PREFIX            := gardener-extension
 NAME                        := shoot-falco-service
 ADMISSION_NAME              := admission-shoot-falco-service
+OPS_NAME					:= falco-ops
 REGISTRY                    := europe-docker.pkg.dev/gardener-project/public/gardener
 IMAGE_PREFIX                := $(REGISTRY)/extensions
 REPO_ROOT                   := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
@@ -99,6 +100,7 @@ docker-login:
 docker-images:
 	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(EXTENSION_PREFIX)-$(NAME):$(VERSION) -t $(IMAGE_PREFIX)/$(EXTENSION_PREFIX)-$(NAME):latest -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(NAME) .
 	@docker build --build-arg EFFECTIVE_VERSION=$(EFFECTIVE_VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):$(VERSION) -t $(IMAGE_PREFIX)/$(ADMISSION_NAME):latest -f Dockerfile -m 6g --target $(EXTENSION_PREFIX)-$(ADMISSION_NAME) .
+	@docker build -t $(REGISTRY)/$(OPS_NAME):$(VERSION) -t $(REGISTRY)/$(OPS_NAME):latest -f Dockerfile -m 6g --target $(OPS_NAME) .
 
 .PHONY: docker-push
 docker-push:
@@ -196,6 +198,8 @@ extension-up: export SKAFFOLD_PUSH = true
 extension-up: export LD_FLAGS = $(shell bash $(GARDENER_HACK_DIR)/get-build-ld-flags.sh k8s.io/component-base $(REPO_ROOT)/VERSION gardener-extension-shoot-falco-service)
 extension-up: export EXTENSION_GARDENER_HACK_DIR = $(GARDENER_HACK_DIR)
 extension-up: $(SKAFFOLD) $(HELM) $(KUBECTL)
+	@docker build -t registry.local.gardener.cloud:5001/local-skaffold/$(OPS_NAME):latest -f Dockerfile --target $(OPS_NAME) .
+	@docker push registry.local.gardener.cloud:5001/local-skaffold/$(OPS_NAME):latest
 	$(SKAFFOLD) run --cache-artifacts=true
 
 extension-debug-up: $(SKAFFOLD) $(HELM) $(KUBECTL)

--- a/charts/internal/falco/templates/0helpers.tpl
+++ b/charts/internal/falco/templates/0helpers.tpl
@@ -114,7 +114,7 @@ Return the proper Falcoctl image name
 Return the proper Falcoheartbeat image name
 */}}
 {{- define "falcoheartbeat.image" -}}
-{{ .Values.falcosidekick.image.image }}
+{{ .Values.falcoOps.image }}
 {{- end -}}
 
 {{/*

--- a/charts/internal/falco/templates/falcosidekick-deployment.yaml
+++ b/charts/internal/falco/templates/falcosidekick-deployment.yaml
@@ -49,7 +49,7 @@ spec:
       {{- end }}
       initContainers:
         - name: configure
-          image: {{ .Values.falcosidekick.image.image }}
+          image: {{ .Values.falcoOps.image }}
           command:
             - sh
           args:

--- a/hack/local-setup/operator-extension-resource.yaml
+++ b/hack/local-setup/operator-extension-resource.yaml
@@ -60,6 +60,9 @@ spec:
             repository: europe-docker.pkg.dev/sap-se-gcp-k8s-delivery/releases-public/registry-1_docker_io/falcosecurity/falco
             tag: sha256:1e5a3275b12987e95b3be993c1d1a357fc9461081cfce8e2981ac9e23554470c
             version: 0.41.3
+          - name: falco-ops
+            repository: registry.local.gardener.cloud:5001/local-skaffold/falco-ops
+            tag: latest
         replicaCount: 1
         resources:
           requests:
@@ -100,6 +103,9 @@ spec:
             repository: europe-docker.pkg.dev/sap-se-gcp-k8s-delivery/releases-public/registry-1_docker_io/falcosecurity/falco
             tag: sha256:1e5a3275b12987e95b3be993c1d1a357fc9461081cfce8e2981ac9e23554470c
             version: 0.41.3
+          - name: falco-ops
+            repository: registry.local.gardener.cloud:5001/local-skaffold/falco-ops
+            tag: latest
         replicaCount: 1
         resources:
           requests:

--- a/hack/validate-imagevector.py
+++ b/hack/validate-imagevector.py
@@ -73,6 +73,8 @@ def check_image(repository: str, tag: str) -> bool:
 def check_images(images: list) -> bool:
     has_error = False
     for image in images:
+        if "tag" not in image:
+            continue
         image_ref = f"{image['repository']}:{image['tag']}"
         if not check_image(image["repository"], image["tag"]):
             print(f"Image {image_ref} not found")

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -111,3 +111,6 @@ images:
       confidentiality_requirement: 'low'
       integrity_requirement: 'low'
       availability_requirement: 'low'
+- name: falco-ops
+  sourceRepository: github.com/gardener/gardener-extension-shoot-falco-service
+  repository: europe-docker.pkg.dev/gardener-project/releases/gardener/falco-ops

--- a/imagevector/imagevector_test.go
+++ b/imagevector/imagevector_test.go
@@ -52,6 +52,9 @@ var _ = Describe("Imagevector", func() {
 
 	It("should have a maintained version for every image", func() {
 		for _, image := range iv {
+			if image.Name != "falco" && image.Name != "falcosidekick" && image.Name != "falcoctl" {
+				continue
+			}
 			found := false
 			for _, fv := range versions.Falco.FalcoVersions {
 				if *image.Version == fv.Version && image.Name == "falco" {

--- a/imagevector/imagevector_test.go
+++ b/imagevector/imagevector_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Imagevector", func() {
 
 	It("should have a maintained version for every image", func() {
 		for _, image := range iv {
-			if image.Name != "falco" && image.Name != "falcosidekick" && image.Name != "falcoctl" {
+			if image.Name == "falco-ops" {
 				continue
 			}
 			found := false

--- a/pkg/values/falcovalues.go
+++ b/pkg/values/falcovalues.go
@@ -23,9 +23,11 @@ import (
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener-extension-shoot-falco-service/falco"
+	"github.com/gardener/gardener-extension-shoot-falco-service/imagevector"
 	"github.com/gardener/gardener-extension-shoot-falco-service/pkg/apis/config"
 	confighelper "github.com/gardener/gardener-extension-shoot-falco-service/pkg/apis/config/helper"
 	apisservice "github.com/gardener/gardener-extension-shoot-falco-service/pkg/apis/service"
@@ -103,6 +105,12 @@ func (c *ConfigBuilder) BuildFalcoValues(ctx context.Context, log logr.Logger, r
 	if err != nil {
 		return nil, err
 	}
+
+	falcoOpsImage, err := imagevector.ImageVector().FindImage("falco-ops")
+	if err != nil {
+		return nil, fmt.Errorf("failed to find falco-ops image: %w", err)
+	}
+	falcoOpsImage.WithOptionalTag(version.Get().GitVersion)
 
 	falcoOutputConfigs := make([]falcoOutputConfig, 0)
 	falcoStdoutLog := false
@@ -474,6 +482,9 @@ func (c *ConfigBuilder) BuildFalcoValues(ctx context.Context, log logr.Logger, r
 			"create": false,
 		},
 		"falcosidekick": falcosidekickConfig,
+		"falcoOps": map[string]any{
+			"image": falcoOpsImage.String(),
+		},
 		"gardenerExtensionShootFalcoService": map[string]any{
 			"output": map[string]string{
 				"eventCollector": destination,


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
Introduces a dedicated `falco-ops` image — a minimal scratch-based container with busybox utilities (sh, awk, date, echo, grep, head, sed, sleep, wget). This image is used for:

- The falcosidekick init container that injects the service account token into the config
- The falco heartbeat sidecar that periodically triggers a detectable `execve` event

Previously, the falcosidekick image itself was used for these tasks, but that image is quite large and should not be used for these operations.

The falco-ops image is built from Alpine's busybox + musl libc, resulting in a ~1MB image with only the necessary tools.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Introduce a dedicated `falco-ops` utility image for init containers and heartbeat sidecar, replacing the dependency on shell tools in the falcosidekick image.
```