### PR TITLE
Fix race condition heartbeat container

### DIFF
--- a/charts/internal/falco/templates/falco-pod-template.tpl
+++ b/charts/internal/falco/templates/falco-pod-template.tpl
@@ -234,16 +234,18 @@ spec:
       command: ["sh", "-c"]
       args: 
         - |
-          until wget -qO- http://127.0.0.1:8765/versions 2>/dev/null; do
+          until wget -qO- http://127.0.0.1:8765/healthz 2>/dev/null; do
             sleep 10
           done
+          sleep 60
+          FALCO_VERSION=$(
+            wget -qO- http://127.0.0.1:8765/versions 2>/dev/null |
+            grep -o '"falco_version":"[^"]*"' |
+            sed 's/"falco_version":"//;s/"//'
+          )
           while true; do
-            export FALCO_VERSION=$(
-              wget -qO- http://127.0.0.1:8765/versions 2>/dev/null |
-              grep -o '"falco_version":"[^"]*"' |
-              sed 's/"falco_version":"//;s/"//'
-            )
-            export HEARTBEAT_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+            HEARTBEAT_TIME=$(date -u +"%Y-%m-%dT%H:%M:%SZ") \
+            FALCO_VERSION="$FALCO_VERSION" \
             /bin/echo "Falco heartbeat" > /dev/null
             seconds_until_next_hour=$((3600 - $(date +%s) % 3600))
             sleep $seconds_until_next_hour


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area robustness
/kind bug

**What this PR does / why we need it**:

Fixes a race condition in the falco heartbeat sidecar where the first heartbeat event was never detected by falco. The sidecar previously polled `/versions` to determine if falco was running, but this endpoint responds before falco's eBPF probes are fully attached. As a result, the first `/bin/echo "Falco heartbeat"` execve was invisible to falco, and the next heartbeat would not fire until the top of the next hour.

Changes:
- Poll `/healthz` instead of `/versions` — this is the same endpoint used by the kubelet readiness probe and only responds once falco is fully operational
- Add an additional 60s delay after `/healthz` passes to ensure eBPF probes are attached
- Fetch `FALCO_VERSION` once after startup instead of every hour (it won't change during the pod's lifetime)
- Pass `FALCO_VERSION` and `HEARTBEAT_TIME` as inline environment variables to the `/bin/echo` command so they are visible to falco's `proc.env[]` field

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix race condition where the first falco heartbeat event was missed because the sidecar fired before falco's eBPF probes were fully attached.
```
