### PR TITLE
Upgrade falcosidekick-fork to `v2.35.1`

### DIFF
--- a/falco/falco-profile.yaml
+++ b/falco/falco-profile.yaml
@@ -28,8 +28,8 @@ spec:
       tag: 2.34.0
       version: 2.34.0
     - repository: europe-docker.pkg.dev/gardener-project/releases/gardener/falcosidekick-fork
-      tag: v2.35.0
-      version: 2.35.0
+      tag: v2.35.1
+      version: 2.35.1
   versions:
     falco:
     - classification: deprecated
@@ -56,5 +56,4 @@ spec:
     - classification: supported
       version: 2.34.0
     - classification: supported
-      version: 2.35.0
-
+      version: 2.35.1

--- a/falco/falcosidekickversions.yaml
+++ b/falco/falcosidekickversions.yaml
@@ -3,5 +3,5 @@
     classification: supported
   - version: 2.34.0
     classification: supported
-  - version: 2.35.0
+  - version: 2.35.1
     classification: supported

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -30,8 +30,8 @@ images:
 - name: falcosidekick
   sourceRepository: github.com/gardener/falcosidekick
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/falcosidekick-fork
-  tag: v2.35.0
-  version: 2.35.0
+  tag: v2.35.1
+  version: 2.35.1
   labels:
   - name: 'gardener.cloud/cve-categorisation'
     value:


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:

Upgrades the falcosidekick-fork image from `v2.35.0` to `v2.35.1`.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Release notes for the patch: https://github.com/gardener/falcosidekick/releases/tag/v2.35.1

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
Upgrade falcosidekick-fork from v2.35.0 to v2.35.1.
```
