### PR TITLE
Adapt VPA resources to explicitly specify update mode `InPlaceOrRecreate`

### DIFF
--- a/charts/gardener-extension-admission-shoot-falco-service/charts/runtime/values.yaml
+++ b/charts/gardener-extension-admission-shoot-falco-service/charts/runtime/values.yaml
@@ -21,7 +21,7 @@ vpa:
     minAllowed:
       memory: 64Mi
   updatePolicy:
-    updateMode: "Recreate"
+    updateMode: "InPlaceOrRecreate"
 webhookConfig:
   serverPort: 10250
 kubeconfig: ""

--- a/charts/gardener-extension-shoot-falco-service/values.yaml
+++ b/charts/gardener-extension-shoot-falco-service/values.yaml
@@ -27,7 +27,7 @@ vpa:
     minAllowed:
       memory: 64Mi
   updatePolicy:
-    updateMode: "Recreate"
+    updateMode: "InPlaceOrRecreate"
 
 falco:
   # PriorityClass to use for Falco shoot deployment


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test
-->
/area auto-scaling
/kind cleanup

**What this PR does / why we need it**:
Gardener's `VPAInPlaceUpdates` feature gate has been promoted and unconditionally enabled. This unconditionally enables the Gardener Resource
  Manager's `vpa-in-place-updates` admission webhook, which was previously mutating the value from `Recreate` to `InPlaceOrRecreate` at admission
  time. This change makes the extension explicitly set the correct value, aligning the code with the actual runtime behavior and removing the implicit
  dependency on the webhook mutation.

**Which issue(s) this PR fixes**:

Part of gardener/gardener#12955

**Special notes for your reviewer**:
N/A

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The update mode of the VerticalPodAutoscaler resources deployed by the gardener-extension-shoot-falco-service is now explicitly set to `InPlaceOrRecreate`, reflecting the actual runtime behavior after the unconditional enablement of the `VPAInPlaceUpdates` feature gate.
```
