### PR TITLE
Fix cert renewal

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -57,10 +57,10 @@ const (
 	FalcoEventDestinationSplunk     = "splunk"
 
 	DefaultCALifetime   = time.Hour * 24 * 365 * 2
-	DefaultCARenewAfter = DefaultCALifetime - 60
+	DefaultCARenewAfter = DefaultCALifetime - 60*24*time.Hour
 
 	DefaultCertificateLifetime   = time.Hour * 24 * 180
-	DefaultCertificateRenewAfter = DefaultCertificateLifetime - 30
+	DefaultCertificateRenewAfter = DefaultCertificateLifetime - 30*24*time.Hour
 
 	DefaultTokenLifetime = time.Hour * 24 * 7
 

--- a/pkg/secrets/certs.go
+++ b/pkg/secrets/certs.go
@@ -160,6 +160,10 @@ func GenerateKeysAndCerts(cas *FalcoCas, namespace string, lifetime time.Duratio
 		return nil, err
 	}
 	serverCaUsage := x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment
+	serverNotAfter := time.Now().Add(lifetime)
+	if cas.ServerCaCert.NotAfter.Before(serverNotAfter) {
+		serverNotAfter = cas.ServerCaCert.NotAfter
+	}
 	serverCrtTemplate := x509.Certificate{
 		SerialNumber: serverCrtSerialNumber,
 		Subject: pkix.Name{
@@ -167,7 +171,7 @@ func GenerateKeysAndCerts(cas *FalcoCas, namespace string, lifetime time.Duratio
 		},
 		SignatureAlgorithm: x509.SHA384WithRSA,
 		NotBefore:          time.Now(),
-		NotAfter:           time.Now().Add(lifetime),
+		NotAfter:           serverNotAfter,
 
 		KeyUsage:              serverCaUsage,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
@@ -190,6 +194,10 @@ func GenerateKeysAndCerts(cas *FalcoCas, namespace string, lifetime time.Duratio
 		return nil, err
 	}
 	clientCaUsage := x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment
+	clientNotAfter := time.Now().Add(lifetime)
+	if cas.ClientCaCert.NotAfter.Before(clientNotAfter) {
+		clientNotAfter = cas.ClientCaCert.NotAfter
+	}
 	clientCrtTemplate := x509.Certificate{
 		SerialNumber: clientCrtSerialNumber,
 		Subject: pkix.Name{
@@ -197,7 +205,7 @@ func GenerateKeysAndCerts(cas *FalcoCas, namespace string, lifetime time.Duratio
 		},
 		SignatureAlgorithm: x509.SHA384WithRSA,
 		NotBefore:          time.Now(),
-		NotAfter:           time.Now().Add(lifetime),
+		NotAfter:           clientNotAfter,
 
 		KeyUsage:              clientCaUsage,
 		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},

--- a/pkg/secrets/certs_test.go
+++ b/pkg/secrets/certs_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/gardener/gardener-extension-shoot-falco-service/pkg/constants"
 	"github.com/gardener/gardener-extension-shoot-falco-service/pkg/secrets"
 )
 
@@ -140,6 +141,85 @@ var _ = Describe("Certificate", func() {
 			Expect(secrets.CertsNeedRegeneration(certs, "kube-system")).To(BeTrue())
 		})
 	})
+
+	Describe("Renewal constants sanity", func() {
+		It("CA renewal threshold should be meaningfully before expiry", func() {
+			Expect(constants.DefaultCALifetime-constants.DefaultCARenewAfter).
+				To(BeNumerically(">=", 24*time.Hour),
+					"DefaultCARenewAfter must be at least 1 day before DefaultCALifetime")
+		})
+
+		It("certificate renewal threshold should be meaningfully before expiry", func() {
+			Expect(constants.DefaultCertificateLifetime-constants.DefaultCertificateRenewAfter).
+				To(BeNumerically(">=", 24*time.Hour),
+					"DefaultCertificateRenewAfter must be at least 1 day before DefaultCertificateLifetime")
+		})
+	})
+
+	Describe("Leaf cert lifetime capping", func() {
+		It("should not cap leaf cert when lifetime is shorter than CA remaining life", func() {
+			caLifetime := time.Hour * 24 * 10
+			cas, err := secrets.GenerateFalcoCas("dummy", caLifetime)
+			Expect(err).NotTo(HaveOccurred())
+
+			leafLifetime := time.Hour * 24 * 5
+			certs, err := secrets.GenerateKeysAndCerts(cas, "kube-system", leafLifetime)
+			Expect(err).NotTo(HaveOccurred())
+
+			// leaf must not outlive CA
+			Expect(certs.ServerCert.NotAfter).To(BeTemporally("<=", cas.ServerCaCert.NotAfter))
+			Expect(certs.ClientCert.NotAfter).To(BeTemporally("<=", cas.ClientCaCert.NotAfter))
+
+			// leaf should be close to the requested lifetime (within a second of clock skew)
+			Expect(certs.ServerCert.NotAfter).To(BeTemporally("~", time.Now().Add(leafLifetime), time.Second))
+			Expect(certs.ClientCert.NotAfter).To(BeTemporally("~", time.Now().Add(leafLifetime), time.Second))
+		})
+
+		It("should cap leaf cert to CA expiry when requested lifetime exceeds CA remaining life", func() {
+			caLifetime := time.Hour * 2
+			cas, err := secrets.GenerateFalcoCas("dummy", caLifetime)
+			Expect(err).NotTo(HaveOccurred())
+
+			leafLifetime := time.Hour * 24 * 365
+			certs, err := secrets.GenerateKeysAndCerts(cas, "kube-system", leafLifetime)
+			Expect(err).NotTo(HaveOccurred())
+
+			// leaf must be capped to CA expiry
+			Expect(certs.ServerCert.NotAfter).To(BeTemporally("~", cas.ServerCaCert.NotAfter, time.Second))
+			Expect(certs.ClientCert.NotAfter).To(BeTemporally("~", cas.ClientCaCert.NotAfter, time.Second))
+		})
+
+		It("should cap leaf cert when CA has very little time remaining", func() {
+			caLifetime := time.Minute * 30
+			cas, err := secrets.GenerateFalcoCas("dummy", caLifetime)
+			Expect(err).NotTo(HaveOccurred())
+
+			leafLifetime := time.Hour * 24
+			certs, err := secrets.GenerateKeysAndCerts(cas, "kube-system", leafLifetime)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(certs.ServerCert.NotAfter).To(BeTemporally("<=", cas.ServerCaCert.NotAfter))
+			Expect(certs.ClientCert.NotAfter).To(BeTemporally("<=", cas.ClientCaCert.NotAfter))
+
+			// leaf should be roughly 30 minutes, not 24 hours
+			Expect(certs.ServerCert.NotAfter).To(BeTemporally("~", time.Now().Add(caLifetime), time.Second))
+			Expect(certs.ClientCert.NotAfter).To(BeTemporally("~", time.Now().Add(caLifetime), time.Second))
+		})
+
+		It("should cap leaf cert exactly at CA expiry boundary", func() {
+			caLifetime := time.Hour * 24
+			cas, err := secrets.GenerateFalcoCas("dummy", caLifetime)
+			Expect(err).NotTo(HaveOccurred())
+
+			// request exactly the same lifetime as the CA — leaf must not exceed it
+			certs, err := secrets.GenerateKeysAndCerts(cas, "kube-system", caLifetime)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(certs.ServerCert.NotAfter).To(BeTemporally("<=", cas.ServerCaCert.NotAfter))
+			Expect(certs.ClientCert.NotAfter).To(BeTemporally("<=", cas.ClientCaCert.NotAfter))
+		})
+	})
+
 })
 
 func verifyCertAgainstCA(cert *x509.Certificate, ca *x509.Certificate) error {

--- a/pkg/secrets/certs_test.go
+++ b/pkg/secrets/certs_test.go
@@ -198,12 +198,9 @@ var _ = Describe("Certificate", func() {
 			certs, err := secrets.GenerateKeysAndCerts(cas, "kube-system", leafLifetime)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(certs.ServerCert.NotAfter).To(BeTemporally("<=", cas.ServerCaCert.NotAfter))
-			Expect(certs.ClientCert.NotAfter).To(BeTemporally("<=", cas.ClientCaCert.NotAfter))
-
-			// leaf should be roughly 30 minutes, not 24 hours
-			Expect(certs.ServerCert.NotAfter).To(BeTemporally("~", time.Now().Add(caLifetime), time.Second))
-			Expect(certs.ClientCert.NotAfter).To(BeTemporally("~", time.Now().Add(caLifetime), time.Second))
+			// leaf should be capped to CA expiry, not 24 hours
+			Expect(certs.ServerCert.NotAfter).To(BeTemporally("~", cas.ServerCaCert.NotAfter, time.Second))
+			Expect(certs.ClientCert.NotAfter).To(BeTemporally("~", cas.ClientCaCert.NotAfter, time.Second))
 		})
 
 		It("should cap leaf cert exactly at CA expiry boundary", func() {


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area security
/kind bug

**What this PR does / why we need it**:

This fixes a bug where (ca) certificates were only renewed nanoseconds before they expire, meaning that they could linger around until the next reconcile cycle and prevent falco from sending events to falcosidkick. This also leads to the situation that certificates are issued for CA, exceeding the lifetime of the CA for almost one month.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix ca certificate expiry check from nanoseconds to days.
```
