### PR TITLE
Fix falcosidekick-fork naming mismatch in `images.yaml`

### DIFF
--- a/falco/falco_test.go
+++ b/falco/falco_test.go
@@ -34,6 +34,9 @@ var _ = Describe("Falco", func() {
 			images := imagevector.ImageVector()
 			for _, fv := range versions.FalcoSidekickVersions.FalcosidekickVersions {
 				img := falcoversions.GetImageForVersion(images, "falcosidekick", fv.Version)
+				if img == nil {
+					img = falcoversions.GetImageForVersion(images, "falcosidekick-fork", fv.Version)
+				}
 				Expect(img).NotTo(BeNil(), "No image for falcosidekick version %s", fv.Version)
 			}
 		})

--- a/hack/generate-falco-profile
+++ b/hack/generate-falco-profile
@@ -23,7 +23,7 @@ with open(sys.argv[1]) as f:
     for im in image_vector["images"]:
         if im["name"] == "falco":
             falco_image_vector_map[im["version"]] = im
-        if im["name"] == "falcosidekick":
+        if im["name"] == "falcosidekick" or im["name"] == "falcosidekick-fork":
             falcosidekick_image_vector_map[im["version"]] = im
         if im["name"] == "falcoctl":
             falcoctl_image_vector_map[im["version"]] = im
@@ -77,7 +77,7 @@ for im in image_vector["images"]:
             "tag": im["tag"],
             "version": im["version"],
         })
-    if im["name"] == "falcosidekick":
+    if im["name"] == "falcosidekick" or im["name"] == "falcosidekick-fork":
         falcosidekick_images.append({
             "repository": im["repository"],
             "tag": im["tag"],
@@ -112,5 +112,4 @@ if has_falcoctl:
     falco_profile["spec"]["images"]["falcoctl"] = falcoctl_images
     falco_profile["spec"]["versions"]["falcoctl"] = falcoctl_versions["falcoctlVersions"]
 
-print(yaml.dump(falco_profile))
-
+print(yaml.dump(falco_profile), end='')

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -27,7 +27,7 @@ images:
       confidentiality_requirement: 'low'
       integrity_requirement: 'low'
       availability_requirement: 'low'
-- name: falcosidekick
+- name: falcosidekick-fork
   sourceRepository: github.com/gardener/falcosidekick
   repository: europe-docker.pkg.dev/gardener-project/releases/gardener/falcosidekick-fork
   tag: v2.35.1

--- a/imagevector/imagevector_test.go
+++ b/imagevector/imagevector_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Imagevector", func() {
 		for _, fv := range versions.FalcoSidekickVersions.FalcosidekickVersions {
 			found := false
 			for _, image := range iv {
-				if *image.Version == fv.Version && image.Name == "falcosidekick" {
+				if *image.Version == fv.Version && (image.Name == "falcosidekick" || image.Name == "falcosidekick-fork") {
 					found = true
 					break
 				}
@@ -63,7 +63,7 @@ var _ = Describe("Imagevector", func() {
 				}
 			}
 			for _, fv := range versions.FalcoSidekickVersions.FalcosidekickVersions {
-				if *image.Version == fv.Version && image.Name == "falcosidekick" {
+				if *image.Version == fv.Version && (image.Name == "falcosidekick" || image.Name == "falcosidekick-fork") {
 					found = true
 					break
 				}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

If the PR affects cryptography or security mechanisms (encryption, keys, ciphers, hashes, signatures, etc.), mark it as crypto relevant.
/label crypto

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area security
/kind bug

**What this PR does / why we need it**:
Fixes a mismatch between the image name (`falcosidekick`) in `imagevector/images.yaml` and the actual resource name (`falcosidekick-fork`). The name now correctly reflects the repository it points to.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Fix mismatch between image name and resource name for falcosidekick-fork in imagevector
```
